### PR TITLE
The breathing was compounding, so every head rotated right round

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,6 +61,18 @@ jobs:
       - name: Do the names in the character files line up?
         run: node tools/check-rig-names.mjs
 
+      # Students with no idle clip stand by holding one frame of their
+      # walk, with breathe() adding a rise and a sway on top. That offset
+      # used to accumulate — every body in the cast rotated its head a
+      # full 180° inside a minute, which reached the live site as heads
+      # rolling round and round. The suite below cannot see it: it runs a
+      # few seconds against a software rasterizer, and the fault grew
+      # with frame rate, so it was faintest exactly where we were
+      # looking. This drives a held figure for a simulated minute at
+      # 60fps instead.
+      - name: Does a standing figure stay where it was put?
+        run: node tools/check-breath.mjs
+
       - name: Drive the campus
         run: node tools/smoke.mjs
 

--- a/index.html
+++ b/index.html
@@ -5186,26 +5186,74 @@ function release(s){
 /* Nobody stands like a statue. A held frame plus a slow rise and fall
    through the spine, a little sway, and a head that is not quite level
    reads as a person waiting; the same frame without it reads as a bug.
-   Applied AFTER the mixer has written the pose, every frame, because
-   the mixer would otherwise overwrite it. */
+   Applied AFTER the mixer has written the pose, every frame.
+ *
+ * This is an ABSOLUTE offset from a remembered base, and it has to be.
+ * The first version added to the bone in place — rotation.x += — on the
+ * stated belief that "the mixer keeps writing the same pose every
+ * update, which is what lets breathe() add to it and not fight it".
+ * That belief is wrong, and it is wrong for exactly the figures this
+ * runs on. PropertyMixer.apply ends with
+ *
+ *     for ( let i = stride, e = stride + stride; i !== e; ++ i )
+ *       if ( buffer[ i ] !== buffer[ i + stride ] ) {
+ *         // value has changed -> update scene graph
+ *         binding.setValue( buffer, offset );
+ *
+ * — the scene graph is touched only when the accumulated value CHANGES.
+ * A held figure is a paused action re-seeking the same frame, so from
+ * the second update onward nothing changes and three.js stops writing
+ * the bone altogether. The += then landed on its own previous result
+ * and compounded: measured at 180° of travel on every body and every
+ * clip in the cast, a head rotating slowly and continuously through the
+ * full circle. That is the "swaying head around and around", the head
+ * thrown back, and the figure with no head visible at all.
+ *
+ * So: remember what the mixer left, and write base × offset. If the
+ * mixer starts writing again — the figure is released, or the clip
+ * plays on — the bone will differ from what we left there last frame,
+ * and that new value becomes the base. Correct whether or not anything
+ * else is driving the bone, and independent of frame rate, which the
+ * old one was not: the drift scaled with fps. */
 const BREATHE = /spine|chest|neck|head/;
+const _brQ = new THREE.Quaternion(), _brE = new THREE.Euler();
+const _brV = new THREE.Vector3();
 function breathe(g, t, phase){
-  if (!g.userData.__breath){
+  let st = g.userData.__breath;
+  if (!st){
     const bones = [];
-    g.traverse(o => { if (o.isBone && BREATHE.test(boneKey(o.name))) bones.push(o); });
+    g.traverse(o => {
+      if (!o.isBone) return;
+      const k = boneKey(o.name);
+      /* Leaf tips — HeadTop_End, head_end — carry no skin and no track.
+         Rotating one moves nothing and only ever accumulated error. */
+      if (!BREATHE.test(k) || /end$|^headtop/.test(k)) return;
+      bones.push(o);
+    });
     /* Lowest first: the rise starts at the waist and arrives at the
-       head, which is the order a breath actually travels. */
-    bones.sort((a, b) => a.position.y - b.position.y);
-    g.userData.__breath = bones.slice(0, 6);
+       head, which is the order a breath actually travels. Sorted by
+       WORLD height — position.y is the bone's offset from its parent,
+       so sorting on it ordered these by bone length and the wave
+       arrived in whatever order the rig happened to be built in. */
+    const worldY = new Map();
+    for (const o of bones) worldY.set(o, o.getWorldPosition(_brV).y);
+    bones.sort((a, b) => worldY.get(a) - worldY.get(b));
+    st = g.userData.__breath = {
+      bones: bones.slice(0, 6),
+      base: bones.slice(0, 6).map(b => b.quaternion.clone()),
+      last: bones.slice(0, 6).map(b => b.quaternion.clone()),
+    };
   }
-  const bones = g.userData.__breath;
-  if (!bones.length) return;
+  if (!st.bones.length) return;
   const b = Math.sin(t * 1.15 + phase);
   const sway = Math.sin(t * 0.42 + phase * 1.7);
-  bones.forEach((bone, i) => {
-    const k = (i + 1) / bones.length;
-    bone.rotation.x += b * 0.011 * k;
-    bone.rotation.z += sway * 0.006 * k;
+  st.bones.forEach((bone, i) => {
+    /* anything other than us wrote this bone — that is the new rest */
+    if (!bone.quaternion.equals(st.last[i])) st.base[i].copy(bone.quaternion);
+    const k = (i + 1) / st.bones.length;
+    _brQ.setFromEuler(_brE.set(b * 0.011 * k, 0, sway * 0.006 * k));
+    bone.quaternion.copy(st.base[i]).multiply(_brQ);
+    st.last[i].copy(bone.quaternion);
   });
 }
 /* Play the clip at the pace the body is actually travelling. Clamped
@@ -6848,6 +6896,15 @@ function lookAtViewer(g, look){
   look.head.quaternion.premultiply(
     parentQ.clone().invert().multiply(C).multiply(parentQ));
   look.head.updateMatrixWorld(true);
+  /* breathe() re-bases a bone whenever it finds a value it did not
+     write itself, and this bone is one of its six. Without this line it
+     would read our correction as the mixer's new rest pose and stack
+     the next breath on top of it, every frame. */
+  const st = g.userData.__breath;
+  if (st){
+    const i = st.bones.indexOf(look.head);
+    if (i >= 0) st.last[i].copy(look.head.quaternion);
+  }
 }
 /* Which way is this body facing? Read off the skeleton rather than
    assumed from a convention the models do not share — one arrived

--- a/sw.js
+++ b/sw.js
@@ -34,7 +34,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v41";
+const VERSION = "pembroke-v42";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 

--- a/tools/check-breath.mjs
+++ b/tools/check-breath.mjs
@@ -1,0 +1,198 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — does a standing figure stay where it was put?
+ *
+ *     node tools/check-breath.mjs [walker ariel ...]     (default: all)
+ *
+ * Students with no idle clip stand by holding one frame of their own
+ * walk, and breathe() adds a slow rise and sway on top so the held
+ * frame reads as a person waiting rather than a statue. That offset is
+ * applied every frame, after the mixer, to the spine, neck and head.
+ *
+ * The first version of breathe() added to the bone in place — a bare
+ * `rotation.x +=` — on the belief that the mixer rewrites the bone from
+ * the clip every update and so resets it. It does not. PropertyMixer.apply
+ * ends with
+ *
+ *     if ( buffer[ i ] !== buffer[ i + stride ] ) {
+ *       // value has changed -> update scene graph
+ *       binding.setValue( buffer, offset );
+ *
+ * and a held figure is a PAUSED action re-seeking the same frame, so the
+ * accumulated value stops changing and three.js stops writing the bone
+ * at all. The += then landed on its own previous output. Every body in
+ * the cast reached 180° of head travel inside a minute — heads rotating
+ * slowly through the full circle, which is what reached the live site as
+ * "swaying head around and around" and "it looks like everyone is on
+ * drugs". It was also frame-rate dependent, so it was worst on the
+ * fastest phones and nearly invisible in a slow headless harness.
+ *
+ * So this drives the real pair — mixer.update(dt) then breathe() — for
+ * a simulated minute and measures how far the head has actually
+ * travelled. Breathing is a couple of degrees. Anything past ten is the
+ * bug coming back.
+ *
+ * breathe() is read out of index.html rather than reimplemented here.
+ * A copy would drift from the original and then this would pass while
+ * the campus rolled its heads, which is the whole failure it exists to
+ * catch.
+ */
+import { chromium } from "playwright";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync, readdirSync } from "node:fs";
+import { resolve, extname, sep } from "node:path";
+
+const ROOT = resolve(new URL("..", import.meta.url).pathname);
+const PORT = 8353;
+const MIME = { ".html": "text/html", ".js": "text/javascript",
+               ".glb": "model/gltf-binary", ".png": "image/png" };
+/* Held at 60fps for a minute. The fault it looks for grew with frame
+   rate, so a slow sample would have understated it. */
+const FPS = Number(process.env.FPS || 60);
+const SECONDS = Number(process.env.SECONDS || 60);
+const LIMIT = 10;                      /* degrees of head travel allowed */
+
+/* ── lift breathe() out of the page it ships in ────────────────────── */
+const src = await readFile(resolve(ROOT, "index.html"), "utf8");
+const from = src.indexOf("const BREATHE = /");
+const mark = src.indexOf("function breathe(g, t, phase){", from);
+if (from < 0 || mark < 0){
+  console.error("check-breath: could not find breathe() in index.html — " +
+                "if it was renamed, this check needs renaming with it");
+  process.exit(2);
+}
+/* brace-match to the end of the function so this survives edits inside it */
+let depth = 0, end = -1;
+for (let i = src.indexOf("{", mark); i < src.length; i++){
+  if (src[i] === "{") depth++;
+  else if (src[i] === "}" && --depth === 0){ end = i + 1; break; }
+}
+if (end < 0){ console.error("check-breath: breathe() has no closing brace"); process.exit(2); }
+const BREATHE_SRC = src.slice(from, end);
+console.log(`breathe() lifted from index.html — ${BREATHE_SRC.split("\n").length} lines\n`);
+
+const pick = process.argv.slice(2).filter(a => !a.startsWith("-"));
+const bodies = readdirSync(resolve(ROOT, "assets"))
+  .filter(f => /^stu_.*\.glb$/.test(f))
+  .filter(f => !pick.length || pick.includes(f.replace(/^stu_|\.glb$/g, "")))
+  .sort();
+
+const PAGE = `<!doctype html><meta charset="utf-8">
+<script type="importmap">{"imports":{
+  "three":"/assets/vendor/three/build/three.module.js",
+  "three/addons/":"/assets/vendor/three/examples/jsm/"}}</script>
+<script type="module">
+import * as THREE from "three";
+import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
+import { MeshoptDecoder } from "three/addons/libs/meshopt_decoder.module.js";
+const loader = new GLTFLoader(); loader.setMeshoptDecoder(MeshoptDecoder);
+
+const boneKey = (s) => {
+  s = (s || "").split("|").pop().split(":").pop();
+  s = s.replace(/^mixamorig\\d*/i, "").replace(/[._]\\d+$/, "");
+  return (s || "").replace(/[^a-z0-9]/gi, "").toLowerCase();
+};
+const DEG = 180 / Math.PI;
+
+/* ── verbatim from index.html ─────────────────────────────────────── */
+${BREATHE_SRC}
+/* ─────────────────────────────────────────────────────────────────── */
+
+window.__breath = (url, fps, seconds) => new Promise((done) => {
+  loader.load(url, (gl) => {
+    const root = gl.scene;
+    root.updateMatrixWorld(true);
+    const holder = new THREE.Group(); holder.add(root);
+
+    let head = null;
+    root.traverse(o => {
+      const k = boneKey(o.name);
+      if (!head && o.isBone && /head/.test(k) && !/top|end/.test(k)) head = o;
+    });
+    if (!head){ done({ err: "no head bone" }); return; }
+
+    const rest = new Map();
+    root.traverse(o => { if (o.isBone) rest.set(o, o.quaternion.clone()); });
+
+    const out = [];
+    for (const clip of gl.animations){
+      for (const [b, q] of rest) b.quaternion.copy(q);
+      delete holder.userData.__breath;
+
+      const mixer = new THREE.AnimationMixer(root);
+      const act = mixer.clipAction(clip);
+      act.reset(); act.play(); act.setEffectiveWeight(1);
+      /* the state breathe() runs in, and the state that stops the mixer
+         writing: paused, re-seeking one frame */
+      act.paused = true;
+      act.time = clip.duration * 0.3;
+
+      const dt = 1 / fps;
+      const q0 = new THREE.Quaternion(), q1 = new THREE.Quaternion();
+      const d = new THREE.Quaternion();
+      mixer.update(0); root.updateMatrixWorld(true);
+      head.getWorldQuaternion(q0);
+      let peak = 0;
+      for (let i = 1; i <= Math.round(fps * seconds); i++){
+        mixer.update(dt);
+        act.time = clip.duration * 0.3;      /* holdStill re-seeks each frame */
+        breathe(holder, i * dt, 0);
+        root.updateMatrixWorld(true);
+        head.getWorldQuaternion(q1);
+        d.copy(q0).invert().multiply(q1);
+        const ang = 2 * Math.acos(Math.min(1, Math.abs(d.w))) * DEG;
+        if (ang > peak) peak = ang;
+      }
+      act.stop(); mixer.uncacheAction(clip);
+      out.push({ clip: clip.name, peak: +peak.toFixed(1) });
+    }
+    done({ bones: (holder.userData.__breath?.bones || []).map(b => b.name), clips: out });
+  }, undefined, (er) => done({ err: String(er).slice(0, 120) }));
+});
+</script>`;
+
+const server = createServer(async (req, res) => {
+  const rel = decodeURIComponent(req.url.split("?")[0]);
+  if (rel === "/"){ res.writeHead(200, { "content-type": "text/html" }); res.end(PAGE); return; }
+  const p = resolve(ROOT, "." + rel);
+  if (!p.startsWith(ROOT + sep) || !existsSync(p) || statSync(p).isDirectory()){
+    res.writeHead(404); res.end("nope"); return; }
+  res.writeHead(200, { "content-type": MIME[extname(p)] || "application/octet-stream" });
+  res.end(await readFile(p));
+});
+await new Promise(r => server.listen(PORT, r));
+
+const browser = await chromium.launch({ args: ["--enable-unsafe-swiftshader", "--no-sandbox"] });
+const page = await browser.newPage();
+page.on("pageerror", e => { console.error("page error: " + e.message); });
+await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded" });
+await page.waitForFunction(() => !!window.__breath, { timeout: 15000 });
+
+console.log(`a held figure breathing at ${FPS}fps for ${SECONDS}s — ` +
+            `how far the head travels\n`);
+const bad = [];
+for (const f of bodies){
+  const name = f.replace(/^stu_|\.glb$/g, "");
+  const r = await page.evaluate(([u, fps, s]) => window.__breath(u, fps, s),
+                                [`/assets/${f}`, FPS, SECONDS]);
+  if (r.err){ console.log(name.padEnd(10) + "FAILED: " + r.err); continue; }
+  const worst = Math.max(...r.clips.map(c => c.peak));
+  const over = r.clips.filter(c => c.peak > LIMIT);
+  console.log(`${name.padEnd(10)} worst ${String(worst).padStart(6)}deg over ` +
+              `${r.clips.length} clip(s)   breathes through ` +
+              r.bones.map(b => b.replace(/_\d+$/, "")).join(" > "));
+  for (const c of over){
+    console.log(`             ${c.clip}: ${c.peak}deg`);
+    bad.push(`${name} / ${c.clip}  ${c.peak}deg`);
+  }
+}
+console.log("\n" + "─".repeat(66));
+if (bad.length){
+  console.log(`breathing is compounding instead of settling — a held head\n` +
+              `should move a couple of degrees, not:\n  ` + bad.join("\n  "));
+} else {
+  console.log(`every held head stays within ${LIMIT}deg — breathing settles`);
+}
+await browser.close(); server.close();
+process.exit(bad.length ? 1 : 0);

--- a/tools/check-breath.mjs
+++ b/tools/check-breath.mjs
@@ -172,11 +172,26 @@ await page.waitForFunction(() => !!window.__breath, { timeout: 15000 });
 console.log(`a held figure breathing at ${FPS}fps for ${SECONDS}s — ` +
             `how far the head travels\n`);
 const bad = [];
+/* A body this could not measure is not a body that passed. Logging the
+   failure and carrying on would let the suite go green having checked
+   nothing — the exact shape of the bug this file exists to catch, where
+   a figure looked fine to every number anyone had thought to print. */
+const unmeasured = [];
 for (const f of bodies){
   const name = f.replace(/^stu_|\.glb$/g, "");
-  const r = await page.evaluate(([u, fps, s]) => window.__breath(u, fps, s),
-                                [`/assets/${f}`, FPS, SECONDS]);
-  if (r.err){ console.log(name.padEnd(10) + "FAILED: " + r.err); continue; }
+  let r;
+  try {
+    r = await page.evaluate(([u, fps, s]) => window.__breath(u, fps, s),
+                            [`/assets/${f}`, FPS, SECONDS]);
+  } catch (e){
+    r = { err: String(e).split("\n")[0].slice(0, 120) };
+  }
+  if (r.err || !r.clips?.length){
+    const why = r.err || "the file carries no clips to hold";
+    console.log(name.padEnd(10) + "NOT MEASURED: " + why);
+    unmeasured.push(`${name}: ${why}`);
+    continue;
+  }
   const worst = Math.max(...r.clips.map(c => c.peak));
   const over = r.clips.filter(c => c.peak > LIMIT);
   console.log(`${name.padEnd(10)} worst ${String(worst).padStart(6)}deg over ` +
@@ -191,8 +206,14 @@ console.log("\n" + "─".repeat(66));
 if (bad.length){
   console.log(`breathing is compounding instead of settling — a held head\n` +
               `should move a couple of degrees, not:\n  ` + bad.join("\n  "));
-} else {
-  console.log(`every held head stays within ${LIMIT}deg — breathing settles`);
+}
+if (unmeasured.length){
+  console.log(`${unmeasured.length} of ${bodies.length} bodies could not be ` +
+              `measured, so nothing here vouches for them:\n  ` + unmeasured.join("\n  "));
+}
+if (!bad.length && !unmeasured.length){
+  console.log(`all ${bodies.length} bodies held for ${SECONDS}s — ` +
+              `every head stays within ${LIMIT}deg, breathing settles`);
 }
 await browser.close(); server.close();
-process.exit(bad.length ? 1 : 0);
+process.exit(bad.length || unmeasured.length ? 1 : 0);


### PR DESCRIPTION
Reported from the live site twice — *"some are swaying head around and around"*, *"it looks like everyone is on drugs"* — and again now, with a figure whose head is thrown back to the sky and another with no head visible at all.

One cause, and it was mine, not the character files'.

## What `breathe()` believed

Students with no idle clip stand by holding one frame of their own walk. `breathe()` then adds a slow rise and sway through the spine, neck and head so a held frame reads as a person waiting rather than a statue. It did that with a bare `rotation.x +=`, on this stated belief:

> the mixer keeps writing the same pose every update, which is what lets breathe() add to it and not fight it

The mixer does not. `PropertyMixer.apply` ends with:

```js
for ( let i = stride, e = stride + stride; i !== e; ++ i )
  if ( buffer[ i ] !== buffer[ i + stride ] ) {
    // value has changed -> update scene graph
    binding.setValue( buffer, offset );
    break;
  }
```

The scene graph is touched **only when the accumulated value changes**. A held figure is a *paused* action re-seeking one frame, so from the second update onward nothing changes and three.js stops writing those bones altogether. The `+=` then landed on its own previous output and compounded.

So the one state `breathe()` runs in is exactly the state that switches off the thing it was relying on.

## How far it went

| | head travel, held one minute |
|---|---|
| before | **180.0°** — every body, every clip in the cast |
| after | **2.1°** |

180° is the metric's ceiling: the heads were rotating continuously through the full circle. Not one bad file — `walker`, `ariel`, `isla`, `kenta`, `nadia`, `nathan`, `skater`, `sophia`, `tutor`, `woman`, `alina`, on all 17 clips between them.

It was also **frame-rate dependent** — the drift scaled with fps. Worst on a fast phone, and nearly invisible in a headless harness, which is the main reason the suite never caught it.

## The fix

`breathe()` now writes `base × offset` from a remembered base instead of adding in place. If anything else writes the bone — the figure is released, the clip plays on — the value will differ from what `breathe()` left there, and that becomes the new base. Correct whether or not the mixer is driving it, and identical at 20, 60 and 144fps.

Two smaller things in the same function:

- Bones were sorted by `position.y` to make the breath travel waist-to-head. That is a bone's offset **from its parent**, so they were ordered by bone length, in whatever order the rig was built. Sorted by world height now.
- The selection pulled in leaf tips — `HeadTop_End`, `head_end` — which carry no skin and no track, so they did nothing but accumulate.

`lookAtViewer` writes the head *after* `breathe()` runs, so it now tells `breathe()` what it left there; otherwise the look-at's correction would be read as a new rest pose and stacked on every frame.

## The check

```
Does a standing figure stay where it was put?     (first time)
```

`check-breath.mjs` drives the real pair — `mixer.update` then `breathe` — for a simulated minute at 60fps and fails past 10°. It lifts `breathe()` out of `index.html` by brace-matching rather than reimplementing it: a copy would drift from the original and then pass while the campus rolled its heads, which is the whole failure it exists to catch. Confirmed it fails on the old form (180°) before trusting it to pass on the new one.

## Still open, and not claimed otherwise

- **"Nobody is walking"** and **"people jammed into a corner"** are not addressed here. I tried to measure them and the attempt was worthless: the headless harness renders **0.10 fps** — four frames in 41 seconds — so students appear to crawl no matter what the code does. Speeds and targets read correctly when sampled directly (20–46 units/s against targets 40–140 units away, which is a 1–5 second walk), so there is no evidence of a movement fault, and no evidence against one either. This needs a machine that can actually paint frames.
- One real mechanism worth recording while it is fresh: `crowded()` refuses any step that closes a gap under 27 units, and a blocked student keeps the same target and re-pauses. If the target lies past whoever is blocking, that can repeat indefinitely — there is no re-route and no timeout. Two thirds of students also pause 1.4–6.6s at *every* waypoint, so waypoints are where crowds gather by design. Either could produce the corner report. Neither is changed here, because I could not reproduce it and would be guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_