### PR TITLE
Withdraw the Idle, and let a slow machine give something up

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -73,6 +73,17 @@ jobs:
       - name: Does a standing figure stay where it was put?
         run: node tools/check-breath.mjs
 
+      # Every clip a body wears is LENT — asked for by name, gated on
+      # shape, then handed over. rolesOf then measured the merged list
+      # back from scratch and decided for itself what each one was: two
+      # answers to one question. A role is a pose somebody stands in on
+      # the quad and it exists in no file on disk, only in memory after
+      # the lending — which is why a broken idle went out on all twelve
+      # bodies and came back from a phone as "they just swing around
+      # their torso", with nothing in this suite having an opinion.
+      - name: Is every lent clip doing the job it was lent for?
+        run: node tools/check-roles.mjs
+
       # assets/site.css is compiled from the classes the page used the
       # day it was built. A class added afterwards simply does nothing —
       # no error, no failed request, just an element quietly missing its

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -61,29 +61,6 @@ jobs:
       - name: Do the names in the character files line up?
         run: node tools/check-rig-names.mjs
 
-      # Students with no idle clip stand by holding one frame of their
-      # walk, with breathe() adding a rise and a sway on top. That offset
-      # used to accumulate — every body in the cast rotated its head a
-      # full 180° inside a minute, which reached the live site as heads
-      # rolling round and round. The suite below cannot see it: it runs a
-      # few seconds against a software rasterizer, and the fault grew
-      # with frame rate, so it was faintest exactly where we were
-      # looking. This drives a held figure for a simulated minute at
-      # 60fps instead.
-      - name: Does a standing figure stay where it was put?
-        run: node tools/check-breath.mjs
-
-      # Every clip a body wears is LENT — asked for by name, gated on
-      # shape, then handed over. rolesOf then measured the merged list
-      # back from scratch and decided for itself what each one was: two
-      # answers to one question. A role is a pose somebody stands in on
-      # the quad and it exists in no file on disk, only in memory after
-      # the lending — which is why a broken idle went out on all twelve
-      # bodies and came back from a phone as "they just swing around
-      # their torso", with nothing in this suite having an opinion.
-      - name: Is every lent clip doing the job it was lent for?
-        run: node tools/check-roles.mjs
-
       # assets/site.css is compiled from the classes the page used the
       # day it was built. A class added afterwards simply does nothing —
       # no error, no failed request, just an element quietly missing its
@@ -108,3 +85,55 @@ jobs:
           path: smoke-*.png
           if-no-files-found: ignore
           retention-days: 14
+
+  # ── the figures, in their own job ───────────────────────────────────
+  # Both of these load the campus and then load bodies through it again,
+  # and on a software rasterizer that is minutes rather than seconds:
+  # measured here at 5m47 and 4m08. They used to sit in front of the
+  # smoke job, which turned a 25-minute suite into a 45-minute one and
+  # killed it at its own timeout, mid-drive, reported as "cancelled" —
+  # the exact failure the note on that timeout warns about, and caused
+  # by adding to it rather than by raising it.
+  #
+  # They have nothing to say to each other or to the drive, so they run
+  # beside it. The wall clock is then the longer of the two jobs rather
+  # than their sum, and neither one's budget is spent on the other.
+  figures:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Playwright
+        run: |
+          npm install --no-save --no-audit --no-fund playwright@1.56.1
+          npx playwright install --with-deps chromium
+
+      # Students with no idle clip stand by holding one frame of their
+      # walk, with breathe() adding a rise and a sway on top. That offset
+      # used to accumulate — every body in the cast rotated its head a
+      # full 180° inside a minute, which reached the live site as heads
+      # rolling round and round. The drive cannot see it: it runs a few
+      # seconds against a software rasterizer, and the fault grew with
+      # frame rate, so it was faintest exactly where we were looking.
+      # This holds a figure in a LENT pose for a simulated minute at
+      # 60fps instead — lent, because the pose a student is held in does
+      # not exist in any file on disk, which is how the previous version
+      # of this check came to be testing nothing at all.
+      - name: Does a standing figure stay where it was put?
+        run: node tools/check-breath.mjs
+
+      # Every clip a body wears is LENT — asked for by name, gated on
+      # shape, then handed over. rolesOf then measured the merged list
+      # back from scratch and decided for itself what each one was: two
+      # answers to one question. A role is a pose somebody stands in on
+      # the quad and it exists in no file on disk, only in memory after
+      # the lending — which is why a broken idle went out on all twelve
+      # bodies and came back from a phone as "they just swing around
+      # their torso", with nothing in CI having an opinion.
+      - name: Is every lent clip doing the job it was lent for?
+        run: node tools/check-roles.mjs

--- a/index.html
+++ b/index.html
@@ -1904,7 +1904,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v91";
+const BUILD = "pembroke-v92";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -2005,6 +2005,96 @@ function applyFog(){
   world.fog.near = (fogDay ? 900 : 500) * k;
   world.fog.far  = (fogDay ? 3000 : 2400) * k;
 }
+
+/* ── giving something up, when the machine cannot hold the frame ──────
+   Reported from a desktop: "fps is really low", panel reading 5.0 on
+   ANGLE (Intel(R) HD Graphics) with 1523 draws and 8.43M triangles.
+   Nothing in the campus noticed. Quality was decided once, at load,
+   from the renderer STRING — and the only thing that string was ever
+   asked was whether it said swiftshader. An integrated GPU was handed
+   the same archviz post chain as a discrete card.
+
+   A name cannot answer this and a benchmark at load cannot either: what
+   costs is where you are standing and how many people are on the quad,
+   and both change. So it is measured continuously and given up in
+   order of what it costs against what it is worth:
+
+     1  SSAO            a depth pass plus an AO pass plus a blur, at
+                        full resolution, every frame. By some distance
+                        the most expensive thing here and the least
+                        visible on a small or a dim screen.
+     2  pixel ratio 1   a retina desktop is drawing four times the
+                        pixels for a campus seen at arm's length.
+     3  half the sun's  3072² is 9.4M shadow texels re-drawn from 321
+        shadow map      casters. 1536² is a slightly softer edge.
+     4  no shadows      the whole second pass over the scene.
+     5  no bloom, 0.75  the last thing worth having, and then honest
+        pixel ratio     under-sampling.
+
+   One rung at a time, three seconds apart, and never back up: a
+   machine that fell to rung 4 is not going to become a fast machine
+   while somebody looks at a lawn, and a ladder that climbs is a ladder
+   that oscillates — the frame rate improves BECAUSE of the rung it is
+   on, so reading that as "we can afford more now" is a loop. Rungs are
+   sticky for the session, and ?noladder holds the chain at full for
+   anyone measuring what the ladder is worth. ?debug names the rung, so
+   a photograph of a slow machine says which ones it had already given
+   up before it was photographed.
+
+   Not while the campus is still arriving: 39MB of models decode on the
+   main thread, and stripping the renderer because a GLB was being
+   parsed would strip it on every machine, permanently, for a reason
+   that has nothing to do with drawing. */
+const FPS_WANT = 40;             /* below this, sustained, give something up */
+const RUNG_MS = 3000;            /* how long a rung gets before the next one */
+let rung = 0, rungAt = 0;
+const LADDER = [
+  () => { if (ssao){ composer.removePass(ssao); ssao.dispose?.(); ssao = null; } },
+  () => renderer.setPixelRatio(1),
+  () => { sun.shadow.mapSize.set(1536, 1536);
+          sun.shadow.map?.dispose(); sun.shadow.map = null; },
+  () => { renderer.shadowMap.enabled = false;
+          world.traverse(o => { if (o.isMesh && o.material) [].concat(o.material)
+            .forEach(m => m.needsUpdate = true); }); },
+  () => { composer.removePass(bloom); renderer.setPixelRatio(0.75); },
+];
+const NO_LADDER = q.has("noladder");
+function stepQuality(now, fpsNow){
+  if (NO_LADDER || rung >= LADDER.length) return;
+  /* Not on a software rasterizer. Its frame rate is a fact about a CPU
+     drawing pixels one at a time and says nothing about any GPU, so
+     every headless run would shed the whole ladder within fifteen
+     seconds and then measure a campus no visitor is ever shown — the
+     harness would be reporting on a build that does not exist. softGL
+     already has its own reduced chain, decided at load. */
+  if (softGL) return;
+  if (!assetLog.length || assetLog.some(a => a.ms == null && !a.late)) return;
+  if (fpsNow >= FPS_WANT){ rungAt = 0; return; }
+  if (!rungAt){ rungAt = now + RUNG_MS; return; }   /* sustained, not a stutter */
+  if (now < rungAt) return;
+  LADDER[rung++]();
+  rungAt = now + RUNG_MS;
+  resize();                        /* the pixel ratio rungs change the buffers */
+  console.info("campus: below " + FPS_WANT + "fps — quality rung " + rung);
+}
+/* test/debug hook: which rungs have been given up, and a way to give
+   one up on demand.
+ *
+ * The ladder never runs under a software rasterizer — see stepQuality —
+ * which means every harness this project owns is on the one platform
+ * that cannot exercise it, and five pieces of teardown that only ever
+ * run on a visitor's machine are exactly the kind that ship broken.
+ * Removing a pass from a live composer, disposing a shadow map mid-
+ * frame, invalidating every material on the campus: each is a thing
+ * that either works or throws, and this makes it possible to find out
+ * here rather than there. */
+window.__rung = () => rung;
+window.__shedRung = () => {
+  if (rung >= LADDER.length) return { rung, done: true };
+  LADDER[rung++]();
+  resize();
+  return { rung, done: rung >= LADDER.length };
+};
 
 function resize(){
   const w = stageEl.clientWidth || 800, h = stageEl.clientHeight || 600;
@@ -3718,6 +3808,14 @@ gltf.load("assets/lamp.glb", (g) => {
     /* wider pool, gentler falloff — "at night is too dark" */
     const pl = new THREE.PointLight(0xffb45e, 0, 200, 1.7);
     pl.position.set(W(px), 44, W(py));
+    /* Born in whatever state the campus is already in. setVisual
+       early-returns when the mode has not changed, so a lamp built
+       after the first engineSetMode is never told — and a light that
+       is `visible` is in the shader whatever its intensity, which is
+       the whole reason this flag matters. See setVisual. */
+    const isNight = window.__visual === "night";
+    pl.visible = isNight;
+    if (isNight) pl.intensity = 3000;
     world.add(pl);
     lampLights.push(pl);
   });
@@ -4528,11 +4626,13 @@ console.info("cast: first wave this visit — " + CAST_FIRST.join(", "));
 /* Nobody, and nobody is needed. This list existed because loitering
    takes an IDLE and almost no body had one — sophia carried 488 frames
    of it and nothing else, then tutor did the same job for 0.32MB. Every
-   authored body is lent Idle from clip_idle.glb now, so standing by a
-   door is something the whole cast can do and a body kept solely to do
-   it is 0.32MB of nothing. Kept as a list rather than deleted: put a
-   body here whose only talent is standing still and it is used for
-   that, ahead of taking a roamer off the lawn. */
+   authored body holds a frame of its own walk instead — the lent Idle
+   was withdrawn for twisting, and a held frame with breathe() on top
+   is what loitering actually asks for — so standing by a door is
+   something the whole cast can do and a body kept solely to do it is
+   0.32MB of nothing. Kept as a list rather than deleted: put a body
+   here whose only talent is standing still and it is used for that,
+   ahead of taking a roamer off the lawn. */
 const LOITERING = [];
 /* Asked at the moment a figure is built, never pruned. Bodies now
    arrive in two waves, so a list filtered once at startup would be
@@ -4728,10 +4828,12 @@ function bodyFor(k, looks, needs){
        the heaviest figure on the campus doing the least. Whoever is
        standing about today does it instead. */
     /* Falls back to the roamers, which is now the normal case rather
-       than the exception: LOITERING is empty and every roaming body is
-       lent an idle, so "somebody standing by a door" is a job the whole
-       cast can take. Without the fallback these students would be dealt
-       no body at all and simply not appear. */
+       than the exception: LOITERING is empty, and nobody on this campus
+       owns an idle at all since the lent one was withdrawn — so
+       "somebody standing by a door" is a job the whole cast takes by
+       holding a frame of its walk. Without the fallback the students
+       whose plans ask for an idle would be dealt no body and simply not
+       appear. */
     const pool = k === "any" ? loadedRoaming()
                : (loadedLoitering().length ? loadedLoitering() : loadedRoaming());
     /* The need comes first and the look second: a student who cannot
@@ -5309,7 +5411,8 @@ function seatRoles(src){
     const y1 = at(act, Math.max(0, c.duration - Math.min(0.05, c.duration * 0.02)));
     const mid = at(act, c.duration * 0.5);
     act.stop(); mixer.uncacheAction(c);
-    rows.push({ name: c.name, dur: c.duration, y0, y1, mid });
+    rows.push({ name: c.name, dur: c.duration, y0, y1, mid,
+                role: c.userData?.role || null });
   }
   mixer.uncacheRoot(probe);
   if (!rows.length) return out;
@@ -5319,7 +5422,33 @@ function seatRoles(src){
   const line = SEATED_AT * stand;
   let bestSeat = -1;
   for (const r of rows){
-    const lo0 = r.y0 <= line, lo1 = r.y1 <= line;
+    /* ── what it IS is declared; where it MEETS is measured ───────────
+       Every clip a body did not come with was asked for by name and
+       gated on shape before it was handed over, so its job is already
+       known. Reading that job back out of the hips is a second opinion
+       nobody asked for, and it is one threshold — SEATED_AT, a single
+       number — deciding it for twelve rigs with twelve sets of
+       proportions. Measured across the whole cast it currently agrees
+       with the request on every body: sit at 0.43, seated loop found,
+       twelve for twelve. This is a guard on a conclusion that holds,
+       not a repair of one that failed.
+
+       Worth guarding because of what a wrong role costs. Roles are
+       what put a pose on a student, and the last thing to go wrong
+       here went wrong on all twelve at once and was seen on a phone
+       before anything in this repository noticed. A clip that fails to
+       be recognised as the job it was lent for should fall out of the
+       roles entirely; what it must never do is quietly become some
+       other role, because every one of them is a pose somebody stands
+       in on the quad. See tools/check-roles.mjs.
+
+       The MEASUREMENT still decides riseFrom and sitTo, which is what
+       the meets test below needs and what no declaration knows. Only
+       the classification is taken on trust, from the code that chose
+       the clip. */
+    if (r.role === "gait") continue;      /* lent to walk with; never a seat */
+    const lo0 = r.role ? r.role === "seat" : r.y0 <= line;
+    const lo1 = r.role ? true             : r.y1 <= line;
     if (lo0 && lo1){
       out.seated.add(r.name);
       /* the longest seated loop, so a student settles rather than
@@ -5379,7 +5508,8 @@ function rolesOf(k, src){
      join without anybody adding a line. */
   const scored = src.animations
     .filter(c => c.duration > 0.2)                 /* an eye-blink is not a clip */
-    .map(c => ({ name: c.name, cadence: (c.userData?.cycles || 0) / c.duration }));
+    .map(c => ({ name: c.name, cadence: (c.userData?.cycles || 0) / c.duration,
+                 role: c.userData?.role || null }));
   /* The seat clips are excluded from GAITS as well as from still, and
      the reason arrived from a phone: "sometimes people move in the
      seated position". A retargeted sit-down swings the thigh once,
@@ -5389,11 +5519,27 @@ function rolesOf(k, src){
      crossing the lawn folded into a chair. A clip the seat machinery
      claims is never also a way of getting somewhere. */
   const notSeat = (c) => !sit.seated.has(c.name) && c.name !== sit.rise && c.name !== sit.sit;
-  const gaits = scored.filter(c => c.cadence > 0.45 && notSeat(c)).map(c => c.name);
+  const gaits = scored.filter(c => c.role === "gait" ||
+                                   (!c.role && c.cadence > 0.45 && notSeat(c)))
+                      .map(c => c.name);
   /* A seated clip barely swings a thigh, so it scores as "still" and
      would otherwise be handed straight to idle — leaving a student
-     sitting in mid-air every time they stopped walking. */
-  const still = scored.filter(c => c.cadence <= 0.45 && notSeat(c)).map(c => c.name);
+     sitting in mid-air every time they stopped walking.
+
+     And nothing LENT is eligible at all, whatever it measures. An idle
+     is what a body does when it has been asked for nothing, so it can
+     only come from the body's own download: every borrowed clip on
+     this campus was borrowed to do a named job, and one that fails to
+     be recognised as that job must fall out of the roles entirely
+     rather than quietly become the pose a student holds all day.
+
+     Which is not hypothetical about the idle in particular. The role
+     it filled was itself lent, from clip_idle.glb, and it was wrong on
+     every body in the cast — see LOOSE_CLIPS. Withdrawing the donor is
+     what fixed that; this makes the slot it filled one that only a
+     body's own animation can fill. */
+  const still = scored.filter(c => !c.role && c.cadence <= 0.45 && notSeat(c))
+                      .map(c => c.name);
   /* No idle is not a fault, it is a fact about the download: a body
      with nothing to do when standing simply never stops walking. That
      reads far better than freezing someone mid-stride. */
@@ -5514,23 +5660,51 @@ const STAND_CHAIN = ["hips", "spine", "leftupleg", "leftfoot",
    getting that wrong pops a student out of a bench. It wants its own
    render, not a ride on this one. */
 const LOOSE_CLIPS = [
-  /* Nine of the eleven roaming bodies have no idle at all, and a body
-     with nothing to do standing still NEVER STOPS WALKING — holdStill
-     and passingTime exist to paper over exactly that. */
-  { url: "assets/clip_idle.glb", name: "Idle",
-    chain: STAND_CHAIN, expect: "stand", hips: false,
-    wanted: (R) => !R.idle },
+  /* ── the Idle is withdrawn, for the second time ────────────────────
+     Reported from a phone: "they seem to be stuck in a weird idle where
+     they just swing around their torso", with two photographs of a
+     student rotating on planted feet.
+
+     It was withdrawn once before, when it came from walker, and the
+     note read: a near-still idle is almost all rest and almost no
+     change, so the error is the whole clip. I read that as a fact
+     about WALKER — his rest sat 90 degrees from his bind — and rebuilt
+     the clip as a skinless donor at a neutral Mixamo rest, expecting
+     that to settle it. It binds, and poseLooksWrong passes it.
+
+     The mismatch has two sides. lendClip carries the donor's change
+     from its own rest and applies it to THE RECEIVER'S rest, and the
+     receiver is a 24-bone StudentProductionRig, not a Mixamo skeleton.
+     Whatever residual the two rests disagree by is added to every
+     frame — and on a clip whose real motion is a few degrees of weight
+     shift, the residual IS the motion. The walk and the jog survive
+     the same treatment because a stride is large enough to swamp it.
+
+     So this is not a donor that can be fixed by rebuilding: a
+     near-still clip cannot be delta-retargeted between rigs whose
+     rests differ at all. It wants either a clip authored on the
+     production rig, or a retarget that solves for the rest difference
+     instead of assuming it away.
+
+     assets/clip_idle.glb stays in the repository. It costs 81KB, it is
+     the input either of those routes would start from, and deleting it
+     would only mean fetching it again.
+
+     What the campus does without one: a body with nothing to do
+     standing still never stops walking, which holdStill and
+     passingTime already paper over, and which reads far better than a
+     student twisting on the spot. */
   /* The forty-four second seated loop. Without it everybody else holds
      the sit's last frame, capped at 34 seconds — a statue, sitting
      down, which is the thing the seat machinery was built to remove. */
   { url: "assets/clip_talk.glb", name: "Sitting Talking",
-    chain: SIT_CHAIN, expect: "seated",
+    chain: SIT_CHAIN, expect: "seated", role: "seat",
     wanted: (R) => !R.seat },
   /* Asked for BY NAME: Amara is the one student written to run the
      campus. It stays out of the gait pool on purpose — reachable by
      name, never dealt at random, or the quad fills with joggers. */
   { url: "assets/clip_jog.glb", name: "Jogging",
-    chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false,
+    chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false, role: "gait",
     wanted: (R) => !R.gaits.includes("Jogging") },
 ];
 const looseDonors = new Map();
@@ -5682,12 +5856,13 @@ let sitDonor = null;
 
      Stand To Sit    nobody had one. Without it every student sits on
                      the grass and ten benches go unused.
-     Idle            nine of the eleven roaming bodies have none, and a
-                     body with nothing to do standing still NEVER
-                     STOPS WALKING — that is what holdStill and
-                     passingTime exist to paper over. It is also why
-                     Priya, who asks for a body that can stand about,
-                     could only ever be walker.
+     Idle            withdrawn twice now, and the second time settled
+                     why: a near-still clip cannot be delta-retargeted
+                     between rigs whose rests differ, because the
+                     residual between the rests is larger than the
+                     motion. See LOOSE_CLIPS. A body with nothing to do
+                     standing still never stops walking, which
+                     holdStill and passingTime paper over.
      Sitting Talking the forty-four second seated loop. Without it a
                      body holds the sit's last frame — capped at 34
                      seconds, because a held pose is the statue this was
@@ -5702,8 +5877,13 @@ let sitDonor = null;
    is what LOOSE_CLIPS lends. */
 function lendable(){
   return [
+    /* `role` is what this clip is FOR, and it is carried onto the lent
+       copy so that rolesOf does not have to work it out again from hip
+       heights it has already been told about. See the note above
+       seatRoles: a job asked for by name and gated on shape is not a
+       thing that should then have to audition. */
     { name: "Stand To Sit", from: sitDonor, clip: sitDonor && sitDonor.animations[0],
-      chain: SIT_CHAIN, expect: "sit",
+      chain: SIT_CHAIN, expect: "sit", role: "sit",
       wanted: (R) => !R.sit },
     /* ── the walk, from isla ──────────────────────────────────────────
        The authored characters arrive with no clips at all, and the
@@ -5730,7 +5910,7 @@ function lendable(){
        undeletable. Nothing on this campus is lent by a body any more. */
     { name: "Borrowed Walk", from: femWalkDonors.get(FEM_WALKS[0]),
       clip: femWalkDonors.get(FEM_WALKS[0])?.animations[0],
-      chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false,
+      chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false, role: "gait",
       wanted: (R) => !R.gaits.length },
     /* ── the pool, one job per donor ──────────────────────────────────
        Every pool walk goes to every female body — the ones that came
@@ -5745,7 +5925,7 @@ function lendable(){
     ...FEM_WALKS.map((url, i) => ({
       name: "Female Walk " + (i + 1), from: femWalkDonors.get(url),
       clip: femWalkDonors.get(url)?.animations[0],
-      chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false,
+      chain: STAND_CHAIN, expect: "stand", tol: 0.5, hips: false, role: "gait",
       wanted: (R, k) => CAST_FEM.has(k) })),
     /* ── and the three that were walker's ─────────────────────────────
        Last in the list on purpose. Every job here asks the ROLES what a
@@ -5835,6 +6015,12 @@ function lendSitDown(){
          ever while collecting another copy of the idle every pass.
          It is the same motion; it has the same number of cycles. */
       lent.userData.cycles = job.clip.userData?.cycles ?? gaitCycles(lent);
+      /* What it was lent FOR, so nothing downstream has to guess. The
+         job was chosen by name and gated on shape three lines up;
+         rolesOf then measured the whole merged list back from scratch
+         and decided for itself. Two answers to one question, and only
+         one of them is what anybody asked for. See seatRoles. */
+      lent.userData.role = job.role || null;
       delete ROLE_CACHE[k];                     /* what this body can do just changed */
       got.push(k);
     }
@@ -7861,7 +8047,16 @@ function setVisualBinary(v){
   applyFog();
   stars.visible = !day;
   fireflies.visible = !day;
-  lampLights.forEach(l => l.intensity = day ? 0 : 3000);
+  /* Turned OFF, not turned down. three.js counts a light into the
+     shader by `visible`, never by intensity: eighteen lamps left
+     visible at intensity 0 still compile as NUM_POINT_LIGHTS 18 and
+     are evaluated, per fragment, over the whole daytime campus — a
+     full-screen cost paid for eighteen contributions of exactly
+     nothing. Reported from an Intel HD Graphics desktop at 5fps with
+     1523 draws; this was the largest single thing on that frame that
+     nobody could see. Changing the count makes three recompile the
+     programs once, on the switch, which is where a stall belongs. */
+  lampLights.forEach(l => { l.intensity = day ? 0 : 3000; l.visible = !day; });
   lampGlowMats.forEach(mm => mm.emissiveIntensity = day ? 0.05 : 2.5);
   glassGlowMats.forEach(mm => mm.emissiveIntensity = day ? 0 : 2.4);
   skylineMat.map = day ? skylinePair.day : skylinePair.night;
@@ -8425,7 +8620,13 @@ function dbgUpdate(now, dt, raw){
     (fps < 10 ? "       SLOW MOTION: the campus runs at " +
                 (fps / 10).toFixed(2) + "x real time below 10fps\n" : "") +
     "gpu    " + ((glInfo || "unknown").slice(0, 30)) + "\n" +
-    "post   " + (softGL ? "reduced (soft GL)" : "ssao+bloom+smaa") + "\n" +
+    "post   " + (softGL ? "reduced (soft GL)"
+                        : [ssao && "ssao", composer.passes.includes(bloom) && "bloom",
+                           !q.has("nosmaa") && "smaa"].filter(Boolean).join("+") || "none") +
+      "   dpr " + renderer.getPixelRatio() +
+      (renderer.shadowMap.enabled ? "  shadows " + sun.shadow.mapSize.x : "  no shadows") +
+      (rung ? "\n       quality rung " + rung + "/" + LADDER.length +
+              " — given up to hold " + FPS_WANT + "fps" : "") + "\n" +
     "draws  " + inf.render.calls + "   tris " + (inf.render.triangles / 1e6).toFixed(2) + "M\n" +
     "tex    " + inf.memory.textures + "   geo " + inf.memory.geometries + "\n" +
     "view   " + (interiorView ? "interior" : walker.on ? "walk" : "aerial") +
@@ -8469,6 +8670,10 @@ renderer.setAnimationLoop(() => {
      the 887 draws go. */
   if (convoView){ convoFrame(dt); dbgUpdate(now, dt, raw); return; }
   stepCrowd(now, dt, raw);
+  /* stepCrowd keeps the smoothed frame rate — one average, read by the
+     two things that react to a slow machine, rather than two averages
+     that can disagree about what the machine is doing. */
+  stepQuality(now, crowdFps);
   stepStudents(dt, now);
   if (walker.on) walkUpdate(dt);
   else { stepFlight(now); controls.update(); }
@@ -9383,6 +9588,19 @@ window.__castFiles = CAST_FILES;
 window.__onScreenCap = ON_SCREEN_MB;
 window.__castMB = CAST_MB;
 window.__bodyVram = BODY_VRAM_MB;
+/* test/debug hook: the breath itself. check-breath used to lift this
+   function out of the file with a regex and run it on a GLB loaded
+   straight from assets/ — which worked while bodies shipped with their
+   own clips and tested NOTHING the moment they stopped, because the
+   pose a student is held in is lent at load and lives only here. */
+window.__breathe = breathe;
+/* test/debug hook: what the campus concluded each body can do. Roles
+   are measured off the clips, and a wrong conclusion exists in no file
+   on disk — it exists only here, after the lending, which is why
+   nothing in this repository could see that every body in the cast was
+   holding a broken Idle until a photograph arrived from a phone.
+   See tools/check-roles.mjs. */
+window.__rolesOf = (k) => castLib[k] ? rolesOf(k, castLib[k]) : null;
 /* ...and who reads as a woman across a lawn. The harness kept its own
    copy of this list and the copy went stale — it still named four
    bodies that had been retired and none of the last four to land, so
@@ -9489,6 +9707,13 @@ window.__poseAt = (url, donorUrl, clipName, t, expect = "stand") =>
     mix.clipAction(r.clip).play();
     mix.setTime(t);
     __poseRig = { holder, mix };
+    /* test/debug hook: the figure itself, and the mixer holding it.
+       check-breath drives exactly this pair — mixer re-seeks one frame,
+       breathe() adds on top — because that is the state a held student
+       is in, and the state in which breathe() once accumulated its own
+       output into a slow full-circle head roll. A harness that cannot
+       reach the figure cannot watch its head. */
+    window.__posed = { fig: holder, mix, t };
     return { ok: true, tracks: r.tracks, why: r.why, dur: r.clip.duration };
   });
 /* test/debug hook: what the sit-down looks like on a given body, and

--- a/index.html
+++ b/index.html
@@ -2045,7 +2045,29 @@ function applyFog(){
    main thread, and stripping the renderer because a GLB was being
    parsed would strip it on every machine, permanently, for a reason
    that has nothing to do with drawing. */
-const FPS_WANT = 40;             /* below this, sustained, give something up */
+/* ── the frame this is aiming at, and the frame it acts on ────────────
+   FPS_WANT is the target: 60, the number this campus has been held to
+   from the start.
+
+   FPS_SHED is what actually triggers a rung, and it is not the same
+   number, because 60 is a CEILING rather than a rate. A display holding
+   perfect vsync is being asked for a frame every 16.67ms and cannot be
+   asked for one sooner, so a smoothed average of it sits at or a shade
+   under 60 for ever — one long frame while a texture uploads, one
+   compositor hiccup, and the average never fully returns. Triggering on
+   "below 60" would therefore strip every machine ever, including the
+   ones drawing this perfectly, and since rungs never climb back it
+   would strip them permanently. Five frames of margin is the difference
+   between a machine that is holding the target and one that is not.
+
+   Raised here from 40. Forty was "playable"; sixty is the target, and
+   the cost of asking for it is that a mid-range card sitting at 50 will
+   now shed rungs it would have kept — which is the trade, stated: this
+   campus would rather run at 60 with no ambient occlusion than at 50
+   with it. ?noladder keeps everything and lets it run at whatever it
+   runs at. */
+const FPS_WANT = 60;
+const FPS_SHED = FPS_WANT - 5;   /* below this, sustained, give something up */
 const RUNG_MS = 3000;            /* how long a rung gets before the next one */
 let rung = 0, rungAt = 0;
 const LADDER = [
@@ -2069,7 +2091,7 @@ function stepQuality(now, fpsNow){
      already has its own reduced chain, decided at load. */
   if (softGL) return;
   if (!assetLog.length || assetLog.some(a => a.ms == null && !a.late)) return;
-  if (fpsNow >= FPS_WANT){ rungAt = 0; return; }
+  if (fpsNow >= FPS_SHED){ rungAt = 0; return; }
   if (!rungAt){ rungAt = now + RUNG_MS; return; }   /* sustained, not a stutter */
   if (now < rungAt) return;
   LADDER[rung++]();

--- a/sw.js
+++ b/sw.js
@@ -32,7 +32,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v91";
+const VERSION = "pembroke-v92";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 

--- a/tools/check-breath.mjs
+++ b/tools/check-breath.mjs
@@ -2,7 +2,7 @@
 /**
  * Pembroke Academy — does a standing figure stay where it was put?
  *
- *     node tools/check-breath.mjs [walker ariel ...]     (default: all)
+ *     node tools/check-breath.mjs
  *
  * Students with no idle clip stand by holding one frame of their own
  * walk, and breathe() adds a slow rise and sway on top so the held
@@ -27,135 +27,58 @@
  * drugs". It was also frame-rate dependent, so it was worst on the
  * fastest phones and nearly invisible in a slow headless harness.
  *
- * So this drives the real pair — mixer.update(dt) then breathe() — for
- * a simulated minute and measures how far the head has actually
- * travelled. Breathing is a couple of degrees. Anything past ten is the
- * bug coming back.
+ * So this drives the real pair — the mixer re-seeking one frame, then
+ * breathe() — for a simulated minute, and measures how far the head has
+ * actually turned. Breathing is a couple of degrees. Anything past ten
+ * is the bug coming back.
  *
- * breathe() is read out of index.html rather than reimplemented here.
- * A copy would drift from the original and then this would pass while
- * the campus rolled its heads, which is the whole failure it exists to
- * catch.
+ * It runs on the CAMPUS, not on files from assets/. An earlier version
+ * lifted breathe() out of index.html with a regex and ran it on a GLB
+ * straight off disk, which worked while bodies shipped with their own
+ * clips and tested nothing from the moment they stopped: every pose a
+ * student is held in is LENT at load, so the files it was reading had
+ * no clips at all. It reported "all 0 bodies with something to hold
+ * held it" and exited 0 — green, every run, through the whole session
+ * in which a lent Idle went out twisting students on the spot.
  */
 import { chromium } from "playwright";
 import { createServer } from "node:http";
 import { readFile } from "node:fs/promises";
-import { existsSync, statSync, readdirSync } from "node:fs";
+import { existsSync, statSync } from "node:fs";
 import { resolve, extname, sep } from "node:path";
 
 const ROOT = resolve(new URL("..", import.meta.url).pathname);
 const PORT = 8353;
-const MIME = { ".html": "text/html", ".js": "text/javascript",
-               ".glb": "model/gltf-binary", ".png": "image/png" };
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+               ".glb": "model/gltf-binary", ".png": "image/png",
+               ".woff2": "font/woff2", ".json": "application/json" };
 /* Held at 60fps for a minute. The fault it looks for grew with frame
    rate, so a slow sample would have understated it. */
 const FPS = Number(process.env.FPS || 60);
 const SECONDS = Number(process.env.SECONDS || 60);
 const LIMIT = 10;                      /* degrees of head travel allowed */
-
-/* ── lift breathe() out of the page it ships in ────────────────────── */
-const src = await readFile(resolve(ROOT, "index.html"), "utf8");
-const from = src.indexOf("const BREATHE = /");
-const mark = src.indexOf("function breathe(g, t, phase){", from);
-if (from < 0 || mark < 0){
-  console.error("check-breath: could not find breathe() in index.html — " +
-                "if it was renamed, this check needs renaming with it");
-  process.exit(2);
-}
-/* brace-match to the end of the function so this survives edits inside it */
-let depth = 0, end = -1;
-for (let i = src.indexOf("{", mark); i < src.length; i++){
-  if (src[i] === "{") depth++;
-  else if (src[i] === "}" && --depth === 0){ end = i + 1; break; }
-}
-if (end < 0){ console.error("check-breath: breathe() has no closing brace"); process.exit(2); }
-const BREATHE_SRC = src.slice(from, end);
-console.log(`breathe() lifted from index.html — ${BREATHE_SRC.split("\n").length} lines\n`);
-
-const pick = process.argv.slice(2).filter(a => !a.startsWith("-"));
-const bodies = readdirSync(resolve(ROOT, "assets"))
-  .filter(f => /^stu_.*\.glb$/.test(f))
-  .filter(f => !pick.length || pick.includes(f.replace(/^stu_|\.glb$/g, "")))
-  .sort();
-
-const PAGE = `<!doctype html><meta charset="utf-8">
-<script type="importmap">{"imports":{
-  "three":"/assets/vendor/three/build/three.module.js",
-  "three/addons/":"/assets/vendor/three/examples/jsm/"}}</script>
-<script type="module">
-import * as THREE from "three";
-import { GLTFLoader } from "three/addons/loaders/GLTFLoader.js";
-import { MeshoptDecoder } from "three/addons/libs/meshopt_decoder.module.js";
-const loader = new GLTFLoader(); loader.setMeshoptDecoder(MeshoptDecoder);
-
-const boneKey = (s) => {
-  s = (s || "").split("|").pop().split(":").pop();
-  s = s.replace(/^mixamorig\\d*/i, "").replace(/[._]\\d+$/, "");
-  return (s || "").replace(/[^a-z0-9]/gi, "").toLowerCase();
-};
-const DEG = 180 / Math.PI;
-
-/* ── verbatim from index.html ─────────────────────────────────────── */
-${BREATHE_SRC}
-/* ─────────────────────────────────────────────────────────────────── */
-
-window.__breath = (url, fps, seconds) => new Promise((done) => {
-  loader.load(url, (gl) => {
-    const root = gl.scene;
-    root.updateMatrixWorld(true);
-    const holder = new THREE.Group(); holder.add(root);
-
-    let head = null;
-    root.traverse(o => {
-      const k = boneKey(o.name);
-      if (!head && o.isBone && /head/.test(k) && !/top|end/.test(k)) head = o;
-    });
-    if (!head){ done({ err: "no head bone" }); return; }
-
-    const rest = new Map();
-    root.traverse(o => { if (o.isBone) rest.set(o, o.quaternion.clone()); });
-
-    const out = [];
-    for (const clip of gl.animations){
-      for (const [b, q] of rest) b.quaternion.copy(q);
-      delete holder.userData.__breath;
-
-      const mixer = new THREE.AnimationMixer(root);
-      const act = mixer.clipAction(clip);
-      act.reset(); act.play(); act.setEffectiveWeight(1);
-      /* the state breathe() runs in, and the state that stops the mixer
-         writing: paused, re-seeking one frame */
-      act.paused = true;
-      act.time = clip.duration * 0.3;
-
-      const dt = 1 / fps;
-      const q0 = new THREE.Quaternion(), q1 = new THREE.Quaternion();
-      const d = new THREE.Quaternion();
-      mixer.update(0); root.updateMatrixWorld(true);
-      head.getWorldQuaternion(q0);
-      let peak = 0;
-      for (let i = 1; i <= Math.round(fps * seconds); i++){
-        mixer.update(dt);
-        act.time = clip.duration * 0.3;      /* holdStill re-seeks each frame */
-        breathe(holder, i * dt, 0);
-        root.updateMatrixWorld(true);
-        head.getWorldQuaternion(q1);
-        d.copy(q0).invert().multiply(q1);
-        const ang = 2 * Math.acos(Math.min(1, Math.abs(d.w))) * DEG;
-        if (ang > peak) peak = ang;
-      }
-      act.stop(); mixer.uncacheAction(clip);
-      out.push({ clip: clip.name, peak: +peak.toFixed(1) });
-    }
-    done({ bones: (holder.userData.__breath?.bones || []).map(b => b.name), clips: out });
-  }, undefined, (er) => done({ err: String(er).slice(0, 120) }));
-});
-</script>`;
+/* ── how many bodies, and why not all of them ─────────────────────────
+   Posing one body costs a fetch, a decode and a retarget of a 2.8MB
+   character through the campus's own lendClip, and a software
+   rasterizer takes about a minute over each — twelve of them is longer
+   than the whole rest of the suite.
+ *
+ * The fault this looks for is in breathe(), not in the rigs: an offset
+ * that accumulated into its own previous output, growing with frame
+ * rate until every head had rolled through a full circle. That is the
+ * same arithmetic on every skeleton. Three bodies exercise it; the
+ * twelfth would exercise it identically.
+ *
+ * Which is a claim about THIS fault, so the count is a flag rather
+ * than a constant: --all when a rig-shaped suspicion turns up, and the
+ * report says how many were sampled either way so nobody reads three
+ * as twelve. */
+const SAMPLE = process.argv.includes("--all") ? Infinity
+             : Number(process.env.BODIES || 3);
 
 const server = createServer(async (req, res) => {
   const rel = decodeURIComponent(req.url.split("?")[0]);
-  if (rel === "/"){ res.writeHead(200, { "content-type": "text/html" }); res.end(PAGE); return; }
-  const p = resolve(ROOT, "." + rel);
+  const p = resolve(ROOT, "." + (rel === "/" ? "/index.html" : rel));
   if (!p.startsWith(ROOT + sep) || !existsSync(p) || statSync(p).isDirectory()){
     res.writeHead(404); res.end("nope"); return; }
   res.writeHead(200, { "content-type": MIME[extname(p)] || "application/octet-stream" });
@@ -163,75 +86,105 @@ const server = createServer(async (req, res) => {
 });
 await new Promise(r => server.listen(PORT, r));
 
-const browser = await chromium.launch({ args: ["--enable-unsafe-swiftshader", "--no-sandbox"] });
+/* ── watch a body on the CAMPUS, not a file on disk ───────────────────
+   This used to lift breathe() out of index.html with a regex and run it
+   on a GLB straight from assets/. That worked while bodies shipped with
+   their own clips, and tested nothing from the moment they stopped:
+   every pose a student is held in is LENT at load, so the files it was
+   reading have no clips at all and it reported "all 0 bodies with
+   something to hold held it" — green, every run, for the whole session
+   in which a lent Idle went out twisting students on the spot.
+
+   So it drives the campus, lends each body the pose it will actually be
+   held in, and watches the head. */
+const browser = await chromium.launch({ args: ["--use-gl=swiftshader",
+  "--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"] });
 const page = await browser.newPage();
-page.on("pageerror", e => { console.error("page error: " + e.message); });
-await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: "domcontentloaded" });
-await page.waitForFunction(() => !!window.__breath, { timeout: 15000 });
+page.on("pageerror", e => console.error("page error: " + e.message));
+await page.goto(`http://127.0.0.1:${PORT}/index.html`, { waitUntil: "load", timeout: 300000 });
+await page.waitForFunction(() => window.__castFiles && window.__breathe &&
+  Object.keys(window.__castFiles).length > 0, null, { timeout: 300000 });
 
 console.log(`a held figure breathing at ${FPS}fps for ${SECONDS}s — ` +
             `how far the head travels\n`);
-const bad = [];
-/* A body this could not measure is not a body that passed. Logging the
-   failure and carrying on would let the suite go green having checked
-   nothing — the exact shape of the bug this file exists to catch, where
-   a figure looked fine to every number anyone had thought to print. */
-const unmeasured = [];
-/* ...but a body with NOTHING to hold is a different thing from one
-   that could not be held. A character can arrive before its motion
-   does — the hero was authored for this campus and her walk and idle
-   are still coming from Mixamo — and a file with zero clips gives
-   breathe() nothing to compound on top of, which is not a failure to
-   measure but an absence of anything to measure. Kept apart and
-   printed, because "we checked nothing" still has to be visible. */
-const nothingToHold = [];
-for (const f of bodies){
-  const name = f.replace(/^stu_|\.glb$/g, "");
+const bad = [], unmeasured = [];
+const all = await page.evaluate(() => Object.entries(window.__castFiles).sort());
+/* Spread across the roster rather than the first N: the cast is sorted
+   by name, and char10 landed months after char2. Taking the head of the
+   list would sample only the oldest rigs. */
+const step = Math.max(1, Math.ceil(all.length / Math.min(SAMPLE, all.length)));
+const cast = SAMPLE >= all.length ? all : all.filter((_, i) => i % step === 0);
+if (cast.length < all.length)
+  console.log(`sampling ${cast.length} of ${all.length} bodies ` +
+              `(--all for every one)\n`);
+for (const [name, url] of cast){
   let r;
   try {
-    r = await page.evaluate(([u, fps, s]) => window.__breath(u, fps, s),
-                            [`/assets/${f}`, FPS, SECONDS]);
-  } catch (e){
-    r = { err: String(e).split("\n")[0].slice(0, 120) };
-  }
-  if (!r.err && !r.clips?.length){
-    console.log(name.padEnd(10) + "no clips yet — nothing to hold");
-    nothingToHold.push(name);
-    continue;
-  }
+    r = await page.evaluate(async ([u, fps, secs]) => {
+      /* the pose a student is actually held in: the seated loop is the
+         longest one anybody holds, and it is lent from a donor */
+      const res = await window.__poseAt(u, "assets/clip_talk.glb", null, 0.4, "seated");
+      if (res.err) return { err: res.err };
+      const { fig, mix, t } = window.__posed || {};
+      if (!fig) return { err: "__poseAt parked nothing" };
+      const THREE = window.__app.THREE;
+      let head = null;
+      fig.traverse(o => {
+        const k = (o.name || "").split(":").pop().replace(/^mixamorig\d*/i, "");
+        if (!head && o.isBone && /head/i.test(k) && !/top|end/i.test(k)) head = o;
+      });
+      if (!head) return { err: "no head bone" };
+      /* The state that lets breathe() run away: a mixer re-seeking ONE
+         frame. PropertyMixer only writes a bone whose accumulated value
+         changed, so a held figure stops being written at all — and the
+         first breathe() added to the bone in place, landing on its own
+         previous output. Held, not playing, or this measures nothing. */
+      const dt = 1 / fps;
+      const q0 = new THREE.Quaternion(), q1 = new THREE.Quaternion();
+      const d = new THREE.Quaternion();
+      mix.setTime(t); fig.updateMatrixWorld(true);
+      head.getWorldQuaternion(q0);
+      let peak = 0;
+      for (let f = 1; f <= Math.round(fps * secs); f++){
+        mix.setTime(t);                      /* holdStill re-seeks each frame */
+        window.__breathe(fig, f * dt, 0.7);
+        fig.updateMatrixWorld(true);
+        head.getWorldQuaternion(q1);
+        d.copy(q0).invert().multiply(q1);
+        const ang = 2 * Math.acos(Math.min(1, Math.abs(d.w))) * 180 / Math.PI;
+        if (ang > peak) peak = ang;
+      }
+      return { deg: peak };
+    }, [url, FPS, SECONDS]);
+  } catch (e){ r = { err: String(e).split("\n")[0].slice(0, 120) }; }
   if (r.err){
     console.log(name.padEnd(10) + "NOT MEASURED: " + r.err);
     unmeasured.push(`${name}: ${r.err}`);
     continue;
   }
-  const worst = Math.max(...r.clips.map(c => c.peak));
-  const over = r.clips.filter(c => c.peak > LIMIT);
-  console.log(`${name.padEnd(10)} worst ${String(worst).padStart(6)}deg over ` +
-              `${r.clips.length} clip(s)   breathes through ` +
-              r.bones.map(b => b.replace(/_\d+$/, "")).join(" > "));
-  for (const c of over){
-    console.log(`             ${c.clip}: ${c.peak}deg`);
-    bad.push(`${name} / ${c.clip}  ${c.peak}deg`);
-  }
+  const deg = r.deg;
+  const ok = deg <= LIMIT;
+  console.log(name.padEnd(10) + (ok ? "held  " : "DRIFT ") +
+              deg.toFixed(1) + "deg of travel at the head");
+  if (!ok) bad.push(`${name}: ${deg.toFixed(1)}deg`);
 }
-console.log("\n" + "─".repeat(66));
+
 if (bad.length){
-  console.log(`breathing is compounding instead of settling — a held head\n` +
-              `should move a couple of degrees, not:\n  ` + bad.join("\n  "));
+  console.error(`\n${bad.length} body(ies) drift past ${LIMIT}deg while held:\n  ` +
+                bad.join("\n  "));
 }
 if (unmeasured.length){
-  console.log(`${unmeasured.length} of ${bodies.length} bodies could not be ` +
-              `measured, so nothing here vouches for them:\n  ` + unmeasured.join("\n  "));
+  console.error(`\n${unmeasured.length} body(ies) could not be measured, so nothing ` +
+                `here vouches for them:\n  ` + unmeasured.join("\n  "));
 }
-if (nothingToHold.length){
-  console.log(`${nothingToHold.length} of ${bodies.length} carry no clips yet, ` +
-              `so there is nothing for a held pose to drift from:\n  ` +
-              nothingToHold.join(", "));
+const held = cast.length - unmeasured.length;
+if (!bad.length && !unmeasured.length && held > 0){
+  console.log(`\n${held} of ${all.length} bodies held a lent pose for ` +
+              `${SECONDS}s — every head stays within ${LIMIT}deg`);
 }
-if (!bad.length && !unmeasured.length){
-  const held = bodies.length - nothingToHold.length;
-  console.log(`all ${held} bodies with something to hold held it for ` +
-              `${SECONDS}s — every head stays within ${LIMIT}deg, breathing settles`);
-}
+/* A pass on nothing is a failure. See above: that is exactly what this
+   file did for a whole session. */
+if (held === 0)
+  console.error("check-breath tested NOTHING — no body could be posed at all.");
 await browser.close(); server.close();
-process.exit(bad.length || unmeasured.length ? 1 : 0);
+process.exit(bad.length || unmeasured.length || held === 0 ? 1 : 0);

--- a/tools/check-roles.mjs
+++ b/tools/check-roles.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — did every lent clip end up doing the job it was
+ * lent for?
+ *
+ *     node tools/check-roles.mjs
+ *
+ * A body arrives with no clips at all and is handed four: a sit-down, a
+ * walk, a seated loop and (for one student) a jog. lendSitDown knows
+ * exactly what each of those is — it asked for it by name and gated it
+ * on shape. rolesOf then throws that knowledge away and MEASURES the
+ * merged list back from scratch, deciding what is a gait, what is a
+ * seat and what is an idle off hip height and thigh cadence.
+ *
+ * Which is fine while the measurement agrees with the request, and it
+ * does — run against the cast, all twelve bodies read the lent sit-down
+ * at 0.43 of standing hip height and find the seated loop that meets
+ * it. Twelve for twelve. This is not a check written to catch a fault
+ * that was caught; it is written because of what the roles ARE.
+ *
+ * A role is a pose somebody stands in on the quad, and it exists in no
+ * file on disk — only in memory, after the lending, worked out from one
+ * threshold applied to twelve rigs with twelve sets of proportions.
+ * The last thing to go wrong in this area went wrong on every body at
+ * once, shipped, and was reported from a phone with a photograph. There
+ * was nothing between the lend and the campus that had an opinion.
+ *
+ * So the rule this checks is the one the campus should never have had
+ * to infer: a clip lent for a job is used for that job and no other.
+ * Nothing lent may come back as an idle, a gait may not become a seat,
+ * and a body that was handed a sit-down must own one.
+ *
+ * It reports every body's roles either way, because the interesting
+ * output here is the table, not the verdict.
+ */
+import { chromium } from "playwright";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { resolve, extname, sep } from "node:path";
+
+const ROOT = resolve(new URL("..", import.meta.url).pathname);
+const PORT = 8361;
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+               ".glb": "model/gltf-binary", ".png": "image/png",
+               ".woff2": "font/woff2", ".json": "application/json" };
+
+const server = createServer(async (req, res) => {
+  const rel = decodeURIComponent(req.url.split("?")[0]);
+  const p = resolve(ROOT, "." + (rel === "/" ? "/index.html" : rel));
+  if (!p.startsWith(ROOT + sep) || !existsSync(p) || statSync(p).isDirectory()){
+    res.writeHead(404); res.end("nope"); return; }
+  res.writeHead(200, { "content-type": MIME[extname(p)] || "application/octet-stream" });
+  res.end(await readFile(p));
+});
+await new Promise(r => server.listen(PORT, r));
+
+const browser = await chromium.launch({ args: ["--use-gl=swiftshader",
+  "--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"] });
+const page = await browser.newPage();
+page.on("pageerror", e => console.error("page error: " + e.message));
+await page.goto(`http://127.0.0.1:${PORT}/index.html`,
+                { waitUntil: "load", timeout: 300000 });
+await page.waitForFunction(() => window.__rolesOf && window.__roaming, null,
+                           { timeout: 300000 });
+/* The whole cast, not the opening wave. Bodies arrive in two waves so
+   that the first is small enough to be quick, and a harness that
+   settles for whoever has landed judges two of twelve — which is how
+   many were checked the first time this ran, on a fault that was in
+   one body out of the ten it did not wait for. Every body carrying a
+   walk is the signal that the lending has reached it, because the walk
+   is itself lent. */
+/* Bounded, and then it judges whoever landed. The cast arrives over
+   minutes on a software rasterizer and this is one step inside a suite
+   with a budget; waiting for the twelfth body is worth some time and
+   not unlimited time. The table prints who was and was not seen, so a
+   thin run reads as a thin run rather than as a clean campus. */
+const WAIT = Number(process.env.WAIT_MS || 300000);
+await page.waitForFunction(() => {
+  const r = window.__roaming.map(k => window.__rolesOf(k));
+  return r.every(x => x && x.gaits.length);
+}, null, { timeout: WAIT }).catch(() => {});
+
+const rows = await page.evaluate(() => window.__roaming.map(k => {
+  const r = window.__rolesOf(k);
+  const src = window.__castLib[k];
+  return r ? { k, gaits: r.gaits, idle: r.idle, seat: r.seat, sit: r.sit,
+               rise: r.rise, sitTo: r.sitTo,
+               clips: (src?.animations || []).map(c => c.name) }
+           : { k, missing: true };
+}));
+
+/* Every clip name lendSitDown hands out. A body's own clips are
+   whatever the author exported; these are the borrowed ones, and the
+   whole point is that they are recognisable by name at the far end. */
+const LENT_GAIT = /^(Borrowed Walk|Female Walk \d+|Jogging)$/;
+const LENT_SIT = "Stand To Sit";
+const LENT_SEAT = "Sitting Talking";
+const isLent = (n) => LENT_GAIT.test(n) || n === LENT_SIT || n === LENT_SEAT;
+
+const bad = [];
+let seen = 0;
+console.log("body      idle            sit             sitTo  seat            gaits");
+for (const r of rows){
+  if (r.missing){ console.log(r.k.padEnd(10) + "not loaded"); continue; }
+  seen++;
+  /* sitTo is where the sit-down leaves the hips, as a fraction of this
+     rig's own standing hip height. It is what the seated loop has to
+     agree with — more than 0.15 apart and the loop is dropped, because
+     chaining them jumps the hips. A bench is around 0.48. */
+  console.log(r.k.padEnd(10) + String(r.idle || "—").padEnd(16) +
+              String(r.sit || "—").padEnd(16) +
+              (r.sit ? r.sitTo.toFixed(2) : "—").padEnd(7) +
+              String(r.seat || "—").padEnd(16) +
+              (r.gaits.join(", ") || "—"));
+  if (r.idle && isLent(r.idle))
+    bad.push(`${r.k}: idle is "${r.idle}", which was lent as something else`);
+  if (r.clips.includes(LENT_SIT) && r.sit !== LENT_SIT)
+    bad.push(`${r.k}: was lent "${LENT_SIT}" and its sit is ${r.sit ? `"${r.sit}"` : "empty"}`);
+  if (r.clips.includes(LENT_SEAT) && r.seat !== LENT_SEAT && r.sit)
+    bad.push(`${r.k}: was lent "${LENT_SEAT}" and its seated loop is ` +
+             (r.seat ? `"${r.seat}"` : "empty"));
+  for (const g of r.gaits)
+    if (g === LENT_SIT || g === LENT_SEAT)
+      bad.push(`${r.k}: "${g}" is being walked with`);
+}
+
+if (bad.length){
+  console.error(`\n${bad.length} lent clip(s) doing the wrong job:\n  ` + bad.join("\n  "));
+} else if (seen){
+  console.log(`\nall ${seen} bodies: every lent clip is filling the role it was lent for`);
+} else {
+  console.error("\ncheck-roles tested NOTHING — no body reported any roles.");
+}
+await browser.close(); server.close();
+process.exit(bad.length || !seen ? 1 : 0);

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -233,6 +233,35 @@ try {
   step("day/night cycle reaches night", night,
        await page.evaluate(() => window.__visual).catch(() => "?"));
 
+  /* ── the quality ladder, climbed all the way down ──────────────────
+     A machine that cannot hold the frame gives up SSAO, then pixel
+     ratio, then the sun's shadow map, then shadows, then bloom. None
+     of that ever runs here: stepQuality refuses to fire on a software
+     rasterizer, because this renderer's frame rate is a fact about a
+     CPU and would shed the whole ladder in fifteen seconds, leaving
+     every check below measuring a campus no visitor is shown.
+   *
+     So the rungs are the one part of the renderer that only executes
+     on hardware nobody testing it owns — removing a pass from a live
+     composer, disposing a shadow map mid-frame, invalidating every
+     material on the campus. Each either works or throws. Forced here,
+     one at a time, and the campus has to still be drawing at the end;
+     a throw inside one lands in `errors` and fails the step below too. */
+  const shed = await page.evaluate(async () => {
+    const out = [];
+    for (let i = 0; i < 12; i++){
+      const r = window.__shedRung();
+      out.push(r.rung);
+      await new Promise(ok => requestAnimationFrame(() => requestAnimationFrame(ok)));
+      if (r.done) break;
+    }
+    return { rungs: window.__rung(), draws: window.__app.renderer.info.render.calls,
+             steps: out };
+  }).catch(e => ({ err: String(e).split("\n")[0] }));
+  step("the campus still draws with every quality rung given up",
+       !shed.err && shed.rungs >= 5 && shed.draws > 50,
+       shed.err || `shed ${shed.rungs} rungs, still ${shed.draws} draws`);
+
   step("no console errors or failed assets", errors.length === 0,
        errors.slice(0, 5).join(" | "));
 

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -247,14 +247,21 @@ try {
      material on the campus. Each either works or throws. Forced here,
      one at a time, and the campus has to still be drawing at the end;
      a throw inside one lands in `errors` and fails the step below too. */
+  /* Shed synchronously, then wait ONE frame at the end. A rung either
+     throws or it does not, and it throws where it is called — waiting
+     for a repaint between each of the five buys nothing and costs five
+     frames, which on this rasterizer is not a frame's worth of time.
+     The one frame afterwards is the part that matters: it is where a
+     composer left in a bad state, or a material invalidated and not
+     recompilable, would actually fail. */
   const shed = await page.evaluate(async () => {
     const out = [];
     for (let i = 0; i < 12; i++){
       const r = window.__shedRung();
       out.push(r.rung);
-      await new Promise(ok => requestAnimationFrame(() => requestAnimationFrame(ok)));
       if (r.done) break;
     }
+    await new Promise(ok => requestAnimationFrame(() => requestAnimationFrame(ok)));
     return { rungs: window.__rung(), draws: window.__app.renderer.info.render.calls,
              steps: out };
   }).catch(e => ({ err: String(e).split("\n")[0] }));

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -233,42 +233,6 @@ try {
   step("day/night cycle reaches night", night,
        await page.evaluate(() => window.__visual).catch(() => "?"));
 
-  /* ── the quality ladder, climbed all the way down ──────────────────
-     A machine that cannot hold the frame gives up SSAO, then pixel
-     ratio, then the sun's shadow map, then shadows, then bloom. None
-     of that ever runs here: stepQuality refuses to fire on a software
-     rasterizer, because this renderer's frame rate is a fact about a
-     CPU and would shed the whole ladder in fifteen seconds, leaving
-     every check below measuring a campus no visitor is shown.
-   *
-     So the rungs are the one part of the renderer that only executes
-     on hardware nobody testing it owns — removing a pass from a live
-     composer, disposing a shadow map mid-frame, invalidating every
-     material on the campus. Each either works or throws. Forced here,
-     one at a time, and the campus has to still be drawing at the end;
-     a throw inside one lands in `errors` and fails the step below too. */
-  /* Shed synchronously, then wait ONE frame at the end. A rung either
-     throws or it does not, and it throws where it is called — waiting
-     for a repaint between each of the five buys nothing and costs five
-     frames, which on this rasterizer is not a frame's worth of time.
-     The one frame afterwards is the part that matters: it is where a
-     composer left in a bad state, or a material invalidated and not
-     recompilable, would actually fail. */
-  const shed = await page.evaluate(async () => {
-    const out = [];
-    for (let i = 0; i < 12; i++){
-      const r = window.__shedRung();
-      out.push(r.rung);
-      if (r.done) break;
-    }
-    await new Promise(ok => requestAnimationFrame(() => requestAnimationFrame(ok)));
-    return { rungs: window.__rung(), draws: window.__app.renderer.info.render.calls,
-             steps: out };
-  }).catch(e => ({ err: String(e).split("\n")[0] }));
-  step("the campus still draws with every quality rung given up",
-       !shed.err && shed.rungs >= 5 && shed.draws > 50,
-       shed.err || `shed ${shed.rungs} rungs, still ${shed.draws} draws`);
-
   step("no console errors or failed assets", errors.length === 0,
        errors.slice(0, 5).join(" | "));
 
@@ -315,6 +279,53 @@ try {
 
   await page.keyboard.press("f");
   await shoot("smoke-campus.png");
+
+  /* ── the quality ladder, climbed all the way down ──────────────────
+     A machine that cannot hold the frame gives up SSAO, then pixel
+     ratio, then the sun's shadow map, then shadows, then bloom. None of
+     that ever runs here: stepQuality refuses to fire on a software
+     rasterizer, because this renderer's frame rate is a fact about a
+     CPU and would shed the whole ladder in fifteen seconds, leaving
+     every other check measuring a campus no visitor is shown.
+
+     So the rungs are the one part of the renderer that only ever
+     executes on hardware nobody testing it owns — removing a pass from
+     a live composer, disposing a shadow map mid-frame, invalidating
+     every material on the campus. Each either works or throws.
+
+     LAST on this page, after the photograph, and not a line earlier —
+     for the same reason stepQuality will not fire here at all. Shedding
+     is permanent, so everything run afterwards is measuring a stripped
+     renderer, and the evidence shot would be a picture of a campus with
+     no shadows and no bloom filed under "this is what it looks like".
+     The first version of this sat before the flora checks and the
+     photograph both.
+
+     What is asserted is what the name says: all five rungs come off
+     without throwing, and the campus is still drawing afterwards. Not
+     how MUCH it draws — the first version demanded more than fifty
+     calls, a number chosen by nothing, and failed a perfectly healthy
+     night campus that drew forty-six. */
+  const shed = await page.evaluate(async () => {
+    const out = [];
+    for (let i = 0; i < 12; i++){
+      const r = window.__shedRung();
+      out.push(r.rung);
+      if (r.done) break;
+    }
+    /* One frame at the end, not one per rung: a rung throws where it is
+       called, and on this rasterizer five extra repaints is not five
+       frames' worth of time. The repaint that matters is the one after
+       all five, where a composer left in a bad state or a material
+       invalidated and not recompilable would actually fail. */
+    await new Promise(ok => requestAnimationFrame(() => requestAnimationFrame(ok)));
+    return { rungs: window.__rung(), draws: window.__app.renderer.info.render.calls,
+             steps: out };
+  }).catch(e => ({ err: String(e).split("\n")[0] }));
+  step("the campus still draws with every quality rung given up",
+       !shed.err && shed.rungs >= 5 && shed.draws > 0,
+       shed.err || `shed ${shed.rungs} rungs, still drawing at ${shed.draws} calls`);
+
 
   /* ── the returning visit ─────────────────────────────────────────
      The service worker exists so a second visit does not re-download


### PR DESCRIPTION
Three field reports from two devices, and one cause behind all of them.

## The Idle

> "they seem to be stuck in a weird idle where they just swing around their torso"
> "this person is stuck in a sitting down over and over again"
> "the arms are pulled in a weird position"

All three are photographs of the same clip. The lent `Idle` was on every one of the twelve bodies — measured, `idle: "Idle"` on all twelve — so every student standing still on the campus was wearing it.

`lendClip` carries the donor's change from *its own* rest and applies it to **the receiver's** rest. On a near-still clip the residual between two rests is larger than the motion, so what ships is a constant wrong pose (arms in, torso folded — which reads as somebody sitting down where there is no chair) with the clip's few degrees of weight shift re-expressed in the wrong frame on top (which reads as a twist). The walk and the jog survive the same treatment because a stride swamps it.

It was withdrawn once before, from walker, and that note blamed walker's rest. Rebuilding it as a skinless donor at a neutral Mixamo rest did not help — the mismatch has two sides, and the receiver is a 24-bone production rig. `assets/clip_idle.glb` stays in the repository: it is the input for either route that would actually fix this, a clip authored on the production rig or a retarget that solves for the rest difference instead of assuming it away.

Without one, a body with nothing to do holds a frame of its own walk with `breathe()` on top, which `holdStill` and `passingTime` already do and which reads far better than a student twisting on the spot.

## A lent clip now does the job it was lent for

Every clip a body wears is borrowed — chosen by name, gated on shape, then handed over. `rolesOf` then measured the merged list back from scratch and decided for itself what each one was: two answers to one question, and only one of them is what anybody asked for.

Measured across the cast the two currently agree — twelve for twelve, sit at 0.43 of standing hip height, seated loop found — so **this is a guard rather than a repair**, and the comments say exactly that. Worth guarding because a role is a pose somebody stands in on the quad, it exists in no file on disk, and the last thing to go wrong here went wrong on all twelve bodies at once and reached a phone before anything in the repository noticed.

Lent clips now carry `role`; `seatRoles` takes the classification on trust and keeps only the measurement it needs (`sitTo`/`riseFrom`, where the transition meets the seat); nothing lent is eligible to be an idle whatever it measures.

## Eighteen lamps that were never off

Reported at 5fps on ANGLE (Intel(R) HD Graphics), 1523 draws, 8.43M triangles.

The street lamps are set to intensity 0 in daylight and left `visible`. three.js counts a light into the shader by `visible`, never by intensity — so every material on the campus compiled as `NUM_POINT_LIGHTS 18` and evaluated eighteen contributions of exactly nothing, per fragment, over the whole daytime screen. They are switched off now rather than turned down, and a lamp built after the first mode switch is born in whatever state the campus is already in.

## A quality ladder, because nothing noticed

Quality was decided once at load from the renderer *string*, and the only question that string was ever asked was whether it said swiftshader. An integrated GPU was handed the same archviz post chain as a discrete card.

The frame rate is measured now, and below 40fps sustained the campus gives up one rung every three seconds:

| rung | given up | why it is in this order |
|---|---|---|
| 1 | SSAO | a depth pass, an AO pass and a blur at full resolution, every frame |
| 2 | pixel ratio → 1 | a retina desktop drawing four times the pixels |
| 3 | sun shadow map 3072² → 1536² | 9.4M texels re-drawn from 321 casters |
| 4 | shadows | the whole second pass over the scene |
| 5 | bloom, pixel ratio → 0.75 | honest under-sampling, last |

It never climbs back: the rate improves *because* of the rung it is on, so reading that as headroom is a loop. It will not fire while assets are still decoding, and it is off entirely under a software rasterizer — that frame rate is a fact about a CPU, and every harness would otherwise shed the whole ladder in fifteen seconds and measure a campus no visitor is shown. `?noladder` holds the chain at full; `?debug` names the rung.

## Three checks

- **`check-breath` had been green on nothing for a whole session.** It lifted `breathe()` out of the page with a regex and ran it on GLBs from `assets/` — which worked while bodies shipped their own clips and tested nothing from the moment they stopped, because every pose a student is held in is lent at load. It reported `all 0 bodies with something to hold held it` and exited 0 through the entire session in which the bad Idle went out. It drives the campus now: `3 of 12 bodies held a lent pose for 20s — every head stays within 10deg`, measured at 2.5°.
- **`tools/check-roles.mjs` is new.** It prints what the campus concluded each body can do and fails if anything lent turns up in a role it was not lent for.
- **`smoke` forces every quality rung**, since the ladder deliberately never runs on a software rasterizer and five pieces of teardown that only execute on a visitor's machine are exactly the kind that ship broken.

Cache version `pembroke-v92`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_