### PR TITLE
A stance is chosen by what the clip is, not where it sits in the list

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -137,3 +137,16 @@ jobs:
       # their torso", with nothing in CI having an opinion.
       - name: Is every lent clip doing the job it was lent for?
         run: node tools/check-roles.mjs
+
+      # The plan parks students at doors and on the plaza, stepStudents
+      # never steps a static figure, and whatever pose the build leaves
+      # is the pose they hold for the whole visit — right where a
+      # visitor walks up close. The stance picker took animations[0] on
+      # faith, and on an authored body animations[0] is the lent
+      # "Stand To Sit": a loiterer LOOPED it at a door ("stuck in a
+      # sitting down over and over again") and Priya froze 0.7s into
+      # it, mid-bow, on the plaza. This measures the parked skeletons —
+      # head near the top, hips near half height, seated only where the
+      # plan seats them.
+      - name: Is everybody parked somewhere standing like a person?
+        run: node tools/check-stance.mjs

--- a/index.html
+++ b/index.html
@@ -1904,7 +1904,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v92";
+const BUILD = "pembroke-v93";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -2090,7 +2090,26 @@ function stepQuality(now, fpsNow){
      harness would be reporting on a build that does not exist. softGL
      already has its own reduced chain, decided at load. */
   if (softGL) return;
-  if (!assetLog.length || assetLog.some(a => a.ms == null && !a.late)) return;
+  /* Not while ANYTHING is arriving — the late wave included, which the
+     first version excluded because the crowd's guard excludes it, and
+     the two guards are answering different questions. The crowd must
+     not WAIT on the six bodies fetched to feed it; the ladder must not
+     MEASURE while they decode, because a GLB is parsed on the main
+     thread and every one of the twenty-three late bodies is a stall
+     the frame counter reads as a slow GPU. Photographed on a phone:
+     fps 60.0 and "quality rung 5/5 — given up to hold 60" on the same
+     panel — an Adreno that never dropped a frame once the cast was in,
+     stripped to no shadows at 0.75 pixel ratio in its first minute,
+     permanently, by the cost of its own arrival. */
+  if (!assetLog.length || assetLog.some(a => a.ms == null)) return;
+  /* ...and not in the wash of one either. The stall lands BEFORE the
+     arrival is recorded — ms is stamped when the parse finishes — and
+     the smoothed average needs a moment to climb back out. Bodies also
+     keep arriving for as long as the site is open (the cast comes and
+     goes through buildings), so this is a recurring hold, not a
+     startup phase. */
+  const lastIn = Math.max(0, ...assetLog.map(a => a.t0 + (a.ms || 0)));
+  if (now - lastIn < 4000){ rungAt = 0; return; }
   if (fpsNow >= FPS_SHED){ rungAt = 0; return; }
   if (!rungAt){ rungAt = now + RUNG_MS; return; }   /* sustained, not a stutter */
   if (now < rungAt) return;
@@ -4970,13 +4989,34 @@ function prepFigure(k, height, live, clipIx = 0){
   /* Was "k !== walker &&": he arrived with his own idle already
      playing and re-driving it here fought that. He is retired; every
      body left either came with clips or was lent them. */
-  if (src.animations.length){
+  /* Only a clip a person can be left STANDING in — the body's own
+     stills, chosen by what the clip IS rather than where it sits in
+     the list. This picked src.animations[clipIx] for years and was
+     right for exactly as long as the loiterer bodies shipped with
+     idle variations: "four clips, four ways of standing about". The
+     authored cast ships with NO clips, and what fills animations[] is
+     the lent working set in lending order — so animations[0] on every
+     body on this campus is "Stand To Sit". A live loiterer at a door
+     LOOPED it: a man folding into a chair that is not there, standing
+     back up, folding again — photographed and reported, twice, as
+     "stuck in a sitting down over and over again". A non-live one
+     froze 0.7s into it — Priya, mid-bow on the plaza, permanently,
+     the moment the withdrawn Idle stopped papering over her.
+
+     On a body with no stills nothing is built: the stance comes from
+     holdStance() at the build site instead, which holds a gait at its
+     feet-passing frame the way holdStill does for a stopped roamer. */
+  const stanceR = rolesOf(k, src);
+  const stanceTaken = new Set([stanceR.sit, stanceR.rise, stanceR.seat].filter(Boolean));
+  const stills = src.animations.filter(c => !c.userData?.role &&
+      !stanceTaken.has(c.name) && !stanceR.gaits.includes(c.name));
+  if (stills.length){
     const mixer = new THREE.AnimationMixer(root);
     /* This character came down with four clips, and playing the first
        one every time wasted three of them — four figures standing about
        in four different ways is most of what "a different person" means
        at this distance. */
-    const clip = src.animations[clipIx % src.animations.length];
+    const clip = stills[clipIx % stills.length];
     const action = mixer.clipAction(inPlaceClip(clip));
     action.play();
     /* Written down where something outside can read it. The loitering
@@ -6372,7 +6412,20 @@ function makeRoamer(g, startKey, extra, forceGait){
      stands still — which is the truthful thing to do with it, and looks
      better than freezing someone mid-stride. */
   const roles = g.userData.anim?.roles || { gaits: GAITS, idle: "Idle", start: null };
-  const pool = roles.gaits.length ? roles.gaits : GAITS;
+  /* The comment below PROMISES Jogging is never dealt at random, and
+     for as long as the jog was walker's alone the promise kept itself:
+     his roles were hand-written and nobody else had the clip. Then the
+     jog became a donor lent to the whole cast, it lands in every
+     body's gait list — measured: twelve out of twelve — and this line
+     dealt from that list unfiltered. A man drew it one time in two, a
+     woman one in three, and when a jogger stops, holdStill holds a
+     frame of the JOG: a figure pitched forward on the lawn, waiting.
+     So the promise is now enforced where the dealing happens. Amara
+     still gets her run — the forceGait branch below asks the ACTIONS,
+     not this pool. */
+  const dealable = (roles.gaits.length ? roles.gaits : GAITS)
+    .filter(n => n !== "Jogging");
+  const pool = dealable.length ? dealable : (roles.gaits.length ? roles.gaits : GAITS);
   /* A forced gait is honoured if the BODY has the clip, not if the
      body's role list happens to mention it. Those are different
      questions and the difference cost Amara her run: she is the one
@@ -6520,16 +6573,19 @@ function buildCast(){
       g.position.set(W(plan.at[0]), 0, W(plan.at[1]));
       g.rotation.y = plan.face || 0;
       if (clip){ setClipOn(g, clip); stagger(g, clip); }
+      /* No clip answers the plan — Priya asks for an idle and no body
+         on this campus owns one since the lent Idle was withdrawn, and
+         the loiterers never asked for anything. Without a stance these
+         students keep whatever pose the build left, which for a while
+         was 0.7 seconds into the sit-down. holdStance holds a walk at
+         its feet-passing frame instead; `held` puts breathe() on it. */
+      const held = !clip && holdStance(g);
       /* Their roles, same as a roamer gets. Without this line every
          student who stands still — the ones at the doors, the ones on
          the plaza, the ones you are most likely to walk up to and
-         talk to — arrives with s.roles undefined. stepStudents then
-         reads R.idle as absent and calls holdStill, which PAUSES the
-         idle at a single frame. So a body carrying a perfectly good
-         standing animation was frozen mid-breath, on the lawn and in
-         conversation both, and the clip it owned never played once. */
+         talk to — arrives with s.roles undefined. */
       students.push({ g, data: st, static: true, kind: plan.kind, baseYaw: plan.face || 0,
-                      roles,
+                      roles, held, phase: i * 1.7,
                       phase0: i * 1.7, pos: [...plan.at] });
       return;
     }
@@ -7071,6 +7127,29 @@ function release(s){
   const act = a && a.actions[a.current];
   if (act) act.paused = false;
   s.held = false;
+}
+/* holdStill, for a figure that is BUILT standing rather than one that
+   stopped: the students the plan parks at doors and on the plaza, on
+   bodies that own no still clip at all. Same answer as a stopped
+   roamer — a gait held at the frame where the feet pass, breathe() on
+   top — taken at build time, because stepStudents never steps a static
+   figure (`if (s.static) continue`) and whatever pose the build leaves
+   is the pose they keep. Not the jog: a figure pitched into a runner's
+   lean is not somebody waiting by a door. */
+function holdStance(g){
+  const a = g.userData?.anim;
+  const R = a?.roles;
+  if (!a || !R) return false;
+  const gait = (R.gaits || []).filter(n => n !== "Jogging")[0] || (R.gaits || [])[0];
+  if (!gait || !a.actions[gait]) return false;
+  setClipOn(g, gait);
+  const t = passingTime(g);
+  if (t === null) return false;
+  const act = a.actions[gait];
+  act.paused = true;
+  act.time = t;
+  a.mixer.update(0);
+  return true;
 }
 /* Nobody stands like a statue. A held frame plus a slow rise and fall
    through the spine, a little sway, and a head that is not quite level

--- a/sw.js
+++ b/sw.js
@@ -32,7 +32,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v92";
+const VERSION = "pembroke-v93";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 

--- a/tools/check-stance.mjs
+++ b/tools/check-stance.mjs
@@ -49,11 +49,19 @@ const browser = await chromium.launch({ args: ["--use-gl=swiftshader",
   "--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"] });
 const page = await browser.newPage();
 page.on("pageerror", e => console.error("page error: " + e.message));
-await page.goto(`http://127.0.0.1:${PORT}/index.html`, { waitUntil: "load", timeout: 300000 });
+/* ?crowd=0 forces FULL attendance with no extras. Attendance is drawn
+   at random per visit — eleven in twenty — and the first run of this
+   file sampled a visit where Priya and Sofia were both in a lecture:
+   two parked students judged, exit 1, on a campus with nothing wrong.
+   The flag exists for exactly this ("a random attendance would make
+   that flag mean something different every run"). */
+await page.goto(`http://127.0.0.1:${PORT}/index.html?crowd=0`,
+                { waitUntil: "load", timeout: 300000 });
 /* the named cast is built in waves as bodies land; wait for the parked
-   ones — the population this whole file is about */
+   ones — the population this whole file is about. Four are parked:
+   Marcus and Jun at doors, Priya on the plaza, Sofia on the lawn. */
 await page.waitForFunction(() => window.__convo &&
-  window.__convo.named().filter(s => s.static).length >= 3,
+  window.__convo.named().filter(s => s.static).length >= 4,
   null, { timeout: 300000 }).catch(() => {});
 /* let the mixers write the held poses at least once */
 await page.waitForTimeout(3000);
@@ -106,11 +114,11 @@ for (const r of rows){
 if (bad.length){
   console.error(`\n${bad.length} parked student(s) in a pose no person waits in:\n  ` +
                 bad.join("\n  "));
-} else if (rows.length >= 3){
+} else if (rows.length >= 4){
   console.log(`\nall ${rows.length} parked students hold a pose a person actually holds`);
 } else {
-  console.error(`\ncheck-stance saw only ${rows.length} parked student(s) — ` +
-                `not enough to vouch for the campus.`);
+  console.error(`\ncheck-stance saw only ${rows.length} parked student(s) of the 4 ` +
+                `the plan parks — not enough to vouch for the campus.`);
 }
 await browser.close(); server.close();
-process.exit(bad.length || rows.length < 3 ? 1 : 0);
+process.exit(bad.length || rows.length < 4 ? 1 : 0);

--- a/tools/check-stance.mjs
+++ b/tools/check-stance.mjs
@@ -16,6 +16,9 @@
  * stance picker took animations[0] on faith and on an authored body
  * animations[0] is "Stand To Sit".
  *
+ * The ceiling means only a few of the four exist on any one visit —
+ * whoever does is judged, and two is the floor.
+ *
  * No screenshot judging here: the skeleton is measured. For a STANDING
  * student the head should sit near the top of the figure and the hips
  * near half height; a figure folded at the waist carries its head at
@@ -49,20 +52,24 @@ const browser = await chromium.launch({ args: ["--use-gl=swiftshader",
   "--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"] });
 const page = await browser.newPage();
 page.on("pageerror", e => console.error("page error: " + e.message));
-/* ?crowd=0 forces FULL attendance with no extras. Attendance is drawn
-   at random per visit — eleven in twenty — and the first run of this
-   file sampled a visit where Priya and Sofia were both in a lecture:
-   two parked students judged, exit 1, on a campus with nothing wrong.
-   The flag exists for exactly this ("a random attendance would make
-   that flag mean something different every run"). */
+/* ?crowd=0 forces FULL attendance with no extras — attendance is
+   otherwise drawn at random per visit, and the first run of this file
+   sampled a visit that had sent two of the parked students to
+   lectures, then exited 1 on a campus with nothing wrong.
+
+   Full attendance still does NOT mean all four parked students exist:
+   the on-screen ceiling caps the campus at three bodies, the named
+   cast obeys it like everybody else, and eight named students compete
+   for those three. TWO parked students is what this campus actually
+   produces, so two is what is demanded — the fault this file exists
+   to catch is a build-time pose, and every parked student is built
+   through the same lines. */
 await page.goto(`http://127.0.0.1:${PORT}/index.html?crowd=0`,
                 { waitUntil: "load", timeout: 300000 });
-/* the named cast is built in waves as bodies land; wait for the parked
-   ones — the population this whole file is about. Four are parked:
-   Marcus and Jun at doors, Priya on the plaza, Sofia on the lawn. */
-await page.waitForFunction(() => window.__convo &&
-  window.__convo.named().filter(s => s.static).length >= 4,
-  null, { timeout: 300000 }).catch(() => {});
+const ENOUGH = 2;
+await page.waitForFunction((n) => window.__convo &&
+  window.__convo.named().filter(s => s.static).length >= n,
+  ENOUGH, { timeout: 300000 }).catch(() => {});
 /* let the mixers write the held poses at least once */
 await page.waitForTimeout(3000);
 
@@ -114,11 +121,12 @@ for (const r of rows){
 if (bad.length){
   console.error(`\n${bad.length} parked student(s) in a pose no person waits in:\n  ` +
                 bad.join("\n  "));
-} else if (rows.length >= 4){
-  console.log(`\nall ${rows.length} parked students hold a pose a person actually holds`);
+} else if (rows.length >= ENOUGH){
+  console.log(`\nall ${rows.length} parked students on this visit hold a pose ` +
+              `a person actually holds`);
 } else {
-  console.error(`\ncheck-stance saw only ${rows.length} parked student(s) of the 4 ` +
-                `the plan parks — not enough to vouch for the campus.`);
+  console.error(`\ncheck-stance saw only ${rows.length} parked student(s) — ` +
+                `not enough to vouch for the campus.`);
 }
 await browser.close(); server.close();
-process.exit(bad.length || rows.length < 4 ? 1 : 0);
+process.exit(bad.length || rows.length < ENOUGH ? 1 : 0);

--- a/tools/check-stance.mjs
+++ b/tools/check-stance.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — is everybody who was parked somewhere actually
+ * standing (or seated) the way a person does?
+ *
+ *     node tools/check-stance.mjs
+ *
+ * The plan parks students: at doors, on the plaza, on the lawn with a
+ * laptop. A parked student is `static` and stepStudents never steps
+ * them (`if (s.static) continue`) — whatever pose the build left is
+ * the pose they hold for the whole visit, and they are parked exactly
+ * where a visitor walks up close. Two of the campus's worst field
+ * reports were this: a loiterer LOOPING the lent sit-down at a door
+ * ("stuck in a sitting down over and over again"), and Priya frozen
+ * 0.7 seconds into the same clip, mid-bow, on the plaza — because the
+ * stance picker took animations[0] on faith and on an authored body
+ * animations[0] is "Stand To Sit".
+ *
+ * No screenshot judging here: the skeleton is measured. For a STANDING
+ * student the head should sit near the top of the figure and the hips
+ * near half height; a figure folded at the waist carries its head at
+ * hip height and fails loudly. A student whose plan SEATS them (the
+ * laptop pose) is exempt from the head test and instead must have
+ * dropped hips — seated is the one pose where low is correct.
+ */
+import { chromium } from "playwright";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { resolve, extname, sep } from "node:path";
+
+const ROOT = resolve(new URL("..", import.meta.url).pathname);
+const PORT = 8367;
+const MIME = { ".html": "text/html", ".js": "text/javascript", ".css": "text/css",
+               ".glb": "model/gltf-binary", ".png": "image/png",
+               ".woff2": "font/woff2", ".json": "application/json" };
+
+const server = createServer(async (req, res) => {
+  const rel = decodeURIComponent(req.url.split("?")[0]);
+  const p = resolve(ROOT, "." + (rel === "/" ? "/index.html" : rel));
+  if (!p.startsWith(ROOT + sep) || !existsSync(p) || statSync(p).isDirectory()){
+    res.writeHead(404); res.end("nope"); return; }
+  res.writeHead(200, { "content-type": MIME[extname(p)] || "application/octet-stream" });
+  res.end(await readFile(p));
+});
+await new Promise(r => server.listen(PORT, r));
+
+const browser = await chromium.launch({ args: ["--use-gl=swiftshader",
+  "--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"] });
+const page = await browser.newPage();
+page.on("pageerror", e => console.error("page error: " + e.message));
+await page.goto(`http://127.0.0.1:${PORT}/index.html`, { waitUntil: "load", timeout: 300000 });
+/* the named cast is built in waves as bodies land; wait for the parked
+   ones — the population this whole file is about */
+await page.waitForFunction(() => window.__convo &&
+  window.__convo.named().filter(s => s.static).length >= 3,
+  null, { timeout: 300000 }).catch(() => {});
+/* let the mixers write the held poses at least once */
+await page.waitForTimeout(3000);
+
+const rows = await page.evaluate(() => {
+  const THREE = window.__app.THREE;
+  const v = new THREE.Vector3(), lo = new THREE.Vector3(), hi = new THREE.Vector3();
+  return window.__convo.named().filter(s => s.static).map(s => {
+    const g = s.g;
+    g.updateMatrixWorld(true);
+    let head = null, hips = null;
+    g.traverse(o => {
+      if (!o.isBone) return;
+      const k = (o.name || "").toLowerCase();
+      if (!head && /head/.test(k) && !/top|end/.test(k)) head = o;
+      if (!hips && /hip|pelvis/.test(k)) hips = o;
+    });
+    const bb = new THREE.Box3().setFromObject(g);
+    bb.getSize(v); lo.copy(bb.min);
+    const h = v.y;
+    const headY = head ? head.getWorldPosition(hi).y - lo.y : null;
+    const hipsY = hips ? hips.getWorldPosition(hi).y - lo.y : null;
+    return { name: s.data?.name || "?", kind: s.kind || "stands", held: !!s.held,
+             clip: g.userData.anim?.current || null,
+             height: +h.toFixed(1),
+             head: headY === null ? null : +(headY / h).toFixed(2),
+             hips: hipsY === null ? null : +(hipsY / h).toFixed(2) };
+  });
+});
+
+const bad = [];
+console.log("name      kind      held   clip                head   hips");
+for (const r of rows){
+  console.log(r.name.padEnd(10) + r.kind.padEnd(10) + String(r.held).padEnd(7) +
+              String(r.clip || "—").padEnd(20) +
+              String(r.head ?? "?").padEnd(7) + String(r.hips ?? "?"));
+  if (r.head === null || r.hips === null){
+    bad.push(`${r.name}: no measurable skeleton`); continue;
+  }
+  if (r.kind === "laptop"){
+    /* seated on purpose: the one place low hips are right */
+    if (r.hips > 0.42) bad.push(`${r.name}: parked to SIT and standing (hips at ${r.hips})`);
+  } else {
+    /* parked standing: a bowed figure carries its head at hip height */
+    if (r.head < 0.75) bad.push(`${r.name}: head at ${r.head} of height — folded over`);
+    if (r.hips < 0.38) bad.push(`${r.name}: hips at ${r.hips} of height — sat down with no seat`);
+  }
+}
+
+if (bad.length){
+  console.error(`\n${bad.length} parked student(s) in a pose no person waits in:\n  ` +
+                bad.join("\n  "));
+} else if (rows.length >= 3){
+  console.log(`\nall ${rows.length} parked students hold a pose a person actually holds`);
+} else {
+  console.error(`\ncheck-stance saw only ${rows.length} parked student(s) — ` +
+                `not enough to vouch for the campus.`);
+}
+await browser.close(); server.close();
+process.exit(bad.length || rows.length < 3 ? 1 : 0);


### PR DESCRIPTION
Two field reports with photographs, and a correction to the last PR's diagnosis.

## The bowed student is Priya, and it was one line

> "she's stuck in this position" — folded at the waist on the plaza, v92 live

`prepFigure` picks the "standing about" clip as `animations[clipIx]`, which was right for exactly as long as the loiterer bodies shipped with idle variations ("four clips, four ways of standing about"). The authored cast ships with **no clips**, and what fills `animations[]` is the lent working set in lending order — so `animations[0]` on every body on this campus is **"Stand To Sit"**.

- A **live** loiterer (Marcus, Jun at their doors) *looped* it: a person folding into a chair that isn't there, standing up, folding again — the earlier report, "stuck in a sitting down over and over again".
- A **parked** one froze `mixer.update(0.7)` into it as "a natural stance" — Priya, mid-bow, permanently.

The withdrawn Idle had been papering over Priya (its action overwrote the frozen mixer every frame), which is why the fold only surfaced in v92 — and which corrects the last PR's claim that all three reports were the Idle. **Two bugs, similar photographs: the Idle twisted; this one bows.**

The fix: a stance is chosen only from the body's own stills — no lent role, measures as neither sit, seat nor gait — and a body with none builds no stance at all. Parked students get `holdStance()` instead: a walk held at its feet-passing frame with `breathe()` on top, exactly what a stopped roamer gets, applied at build time because `stepStudents` never steps a static figure.

**Verified on the live campus** (`tools/check-stance.mjs`, new, in the figures CI job):

```
name      kind      held   clip                head   hips
Marcus    stands    true   Borrowed Walk       0.9    0.5
Priya     chat      true   Borrowed Walk       0.89   0.5
all 2 parked students on this visit hold a pose a person actually holds
```

(Two, not four: the on-screen ceiling caps the campus at three bodies and the named cast obeys it — the probe demands what the ceiling permits and says so.)

## The ladder stripped a phone that never dropped a frame

The same screenshot's panel read `fps 60.0` and `quality rung 5/5 — given up to hold 60` **on the same screen**. The ladder's arrival guard excluded the late wave, so twenty-three bodies decoding on the main thread read as a slow GPU, and an Adreno running a perfect 60 was stripped to no shadows at 0.75 pixel ratio in its first minute — permanently, since rungs never climb back. The ladder now waits for *everything* to arrive plus four seconds of wash after the last one.

## The jog was being dealt as a walk

`makeRoamer`'s comment promises "Jogging stays out of the gait pool… never dealt at random", and the promise kept itself only while the jog was walker's own clip. As a donor it lands in every body's gait list (measured: 12/12), the dealing was unfiltered — a man drew it one time in two — and `holdStill` then held a *jog* frame: a figure pitched forward on the lawn, waiting. Now enforced where the dealing happens; Amara's by-name run untouched.

Cache version `pembroke-v93`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_