### PR TITLE
The floating girl, the roads into walls, and the black frames

### DIFF
--- a/index.html
+++ b/index.html
@@ -1919,7 +1919,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v95";
+const BUILD = "pembroke-v96";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -2669,6 +2669,11 @@ lot(16, 430, 70, 240, 5);
      from the south-west, curving north past the residence hall, around
      the top of the campus and back down the east side to the gates. */
   const drive = (pts, width = 34) => {
+    /* test/debug hook: the road plan, so a harness can drive the same
+       Catmull-Rom the ribbon does and ask whether any road runs into
+       a building — which four of them did, for weeks, invisibly at
+       the old wall heights. */
+    (window.__drives = window.__drives || []).push({ pts, width });
     const t = asphaltTex.clone();
     t.repeat.set(1, 1); t.needsUpdate = true;
     const mat = new THREE.MeshStandardMaterial({ map: t, roughness: 1 });
@@ -2696,9 +2701,19 @@ lot(16, 430, 70, 240, 5);
       transparent: true, blending: THREE.AdditiveBlending, depthWrite: false })));
     world.add(dash);
   };
-  drive([[-40, 1080], [40, 980], [70, 880], [64, 700], [50, 560],
-         [70, 400], [140, 250], [300, 150], [500, 110], [700, 140],
-         [880, 240], [960, 400], [980, 600], [966, 800], [930, 950],
+  /* Re-routed, numerically. "Roads go straight into building": the
+     old control points ran the carriageway INTO the library by 70
+     units, the engineering hall by 52, the east range by 42 and the
+     moved residence hall by 20 — always had, but at 74-unit walls a
+     road clipping a plinth read as "beside", and at 133 it reads as
+     what it is. These points were solved against every footprint with
+     the ribbon's own Catmull-Rom sampling (the curve bows outside its
+     control polygon, so eyeballing the points is how the old ones
+     happened): every edge now clears every wall, kerb included. */
+  drive([[-40, 1080], [40, 980], [70, 880], [64, 700], [40, 560],
+         [38, 460], [46, 368], [72, 262], [97, 185], [179, 103],
+         [350, 104], [500, 102], [700, 114], [803, 115], [885, 160],
+         [952, 257], [960, 400], [980, 600], [966, 800], [930, 950],
          [880, 1060]]);
   /* the boulevard south from the gatehouse to the stadium forecourt */
   drive([[500, 985], [500, 1050], [498, 1105], [500, 1160]], 46);
@@ -2710,8 +2725,12 @@ lot(16, 430, 70, 240, 5);
   /* service loops to the lots either side */
   drive([[64, 700], [10, 690], [-40, 700]], 24);
   drive([[966, 800], [1020, 790], [1070, 800]], 24);
-  /* the residence hall forecourt, off the drive on the west side */
-  drive([[122, 262], [176, 232], [214, 226]], 22);
+  /* The residence hall forecourt — pointing at the residence hall.
+     The hall moved south to plane 460 two passes ago and this spur
+     kept serving the empty lawn where it used to stand, then ran its
+     far end into the library's corner. It now leaves the re-routed
+     west leg and stops short of the hall's west face. */
+  drive([[38, 460], [56, 461], [68, 460]], 22);
   for (let k = 0; k < 6; k++){     /* zebra crossing where the south walk meets the drive */
     const stripe = new THREE.Mesh(new THREE.PlaneGeometry(34, 3.2), dashMat);
     stripe.rotation.x = -Math.PI / 2;
@@ -4848,7 +4867,15 @@ const CAST_PLAN = [
   { k: "loiter", at: [286, 838], face:  0.2, live: true, pose: 1 }, /* Jun — Alden front.
      He stood at 270,700 — inside the science hall, behind its south
      wall. Out on the front now, facing the quad. */
-  { k: "any", needs: "seat", at: [543, 449], face: -2.4,    /* Sofia  — lawn         */
+  /* Sofia — ON A BENCH. Her plan parked her on open lawn playing the
+     seated loop, and a seated pose holds the hips at bench height —
+     lendClip writes the descent as a vertical drop to sitTo, about
+     nine units up. Under the old slouching Sitting Talking that read
+     as lounging on the grass; the authored Sitting Idle is an upright
+     chair-sit, and she became "a girl sitting on the air". The pose
+     was never wrong — the chair was missing. This is the ring bench
+     at 15 degrees; freeSeat knows to leave it hers. */
+  { k: "any", needs: "seat", at: [614, 530.5], face: 1.309,
     kind: "laptop", clip: "seat" },
   { k: "any" },                                             /* Theo   — roams        */
   /* Amara used to lap the ring at 182 — which, with the player standing
@@ -7530,6 +7557,11 @@ function freeSeat(from){
   let best = null, bestD = SIT_RANGE;
   for (const seat of SEATS){
     if (seat.taken) continue;
+    /* Sofia is parked on this one for the whole visit, and she is
+       static — she never claims it through the roamer machinery, so
+       without this line a roamer sits down in her lap. */
+    if (students.some(o => o.static && o.kind === "laptop" &&
+        Math.hypot(seat.x - o.pos[0], seat.y - o.pos[1]) < 8)) continue;
     const d = Math.hypot(seat.x - from.pos[0], seat.y - from.pos[1]);
     if (d < bestD){ bestD = d; best = seat; }
   }
@@ -8652,10 +8684,18 @@ renderer.domElement.addEventListener("touchend", (e) => {
 }, { passive: true });
 
 function collide(nx, ny){
-  /* Shoulder width. The tightest gap on the main walk measures 48 units,
-     and at r=9 that left barely a body's clearance either side — enough
-     to catch on constantly while moving. */
-  const r = 6;
+  /* Shoulder width — and the CAMERA's, which is the part that was
+     wrong. Buttress piers stand proud of every lancet facade by five
+     units, the colliders are the bare footprint, and the near plane
+     sits two units ahead of the eye: at r=6 a walker hugging a wall
+     put the near plane INSIDE the piers, and the screen went black
+     each time one swept through — reported as "the screen goes in and
+     out of black" and, along the north ring where the walk runs flush
+     against the flanker faces, as the quad being unwalkable. r=10
+     keeps eye plus near plane clear of the deepest relief. The
+     tightest pass is the gate arch at 36: sixteen units of corridor
+     remain, and the tightest open-walk gap of 48 keeps twenty-eight. */
+  const r = 10;
   /* The old fence stopped at the campus edge, which was fine while the
      ways did too. Now that roads and walks run out to the stadium, the
      ballpark, the walker has to be allowed to follow

--- a/sw.js
+++ b/sw.js
@@ -32,7 +32,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v95";
+const VERSION = "pembroke-v96";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -220,6 +220,42 @@ try {
   step("the walk-in point is not inside a wall", trapped.length === 0,
        trapped.join(" | ") || "clear of every collider");
 
+  /* Every road, driven along its own curve, against every wall. Four
+     drives ran into buildings for weeks — the ribbon's Catmull-Rom
+     bows outside its control polygon, so points that LOOK clear are
+     not — and it only became visible when the walls grew tall enough
+     to make "beside" read as "into". Sampled here exactly the way
+     ribbonGeom samples it. Walks are excluded on purpose: the south
+     walk threads the gate arch, which straddles it by design. */
+  const roadHits = await page.evaluate(() => {
+    const bad = [];
+    for (const { pts, width } of (window.__drives || [])){
+      const P = [pts[0], ...pts, pts[pts.length - 1]];
+      const half = width / 2 + 3.5 - 6;      /* kerb slack */
+      for (let i = 1; i < P.length - 2; i++){
+        for (let j = 0; j <= 32; j++){
+          const t = j / 32, t2 = t * t, t3 = t2 * t;
+          const C = (a, b, c, d) => 0.5 * ((2 * b) + (-a + c) * t +
+            (2 * a - 5 * b + 4 * c - d) * t2 + (-a + 3 * b - 3 * c + d) * t3);
+          const x = C(P[i-1][0], P[i][0], P[i+1][0], P[i+2][0]);
+          const y = C(P[i-1][1], P[i][1], P[i+1][1], P[i+2][1]);
+          for (const c of window.__colliders){
+            const dx = Math.max(c.x - x, 0, x - (c.x + c.w));
+            const dy = Math.max(c.y - y, 0, y - (c.y + c.d));
+            const inside = x >= c.x && x <= c.x + c.w && y >= c.y && y <= c.y + c.d;
+            if (inside || Math.hypot(dx, dy) < half){
+              bad.push(`road at ${x.toFixed(0)},${y.toFixed(0)} vs wall at ${c.x},${c.y}`);
+              if (bad.length > 4) return bad;
+            }
+          }
+        }
+      }
+    }
+    return bad;
+  });
+  step("no road runs into a building", roadHits.length === 0,
+       roadHits.join(" | ") || "every carriageway clears every wall");
+
   /* the chapel lives on the North Quad now — same sector key, new door */
   await page.evaluate(() => { const w = window.__walker; w.x = 500; w.y = -292; w.h = 0; });
   const doored = await page


### PR DESCRIPTION
Three field reports from v95, each traced to its mechanism:

**"a girl sitting on the air"** — Sofia. Her plan parked her on open lawn playing the seated loop, and a seated pose holds hips at bench height (`lendClip` writes the descent as a vertical drop to `sitTo`, ~9 units up). The old slouching Sitting Talking read as lounging on grass; the authored Sitting Idle is an upright chair-sit, so the missing chair became visible. **The pose was never wrong — the chair was missing.** She now sits on the ring bench at 15°, and `freeSeat` leaves that bench hers.

**"roads go straight into building"** — they always did; the walls were too short to show it. Audited with the ribbon's own Catmull-Rom sampling:

```
main drive into lib hall    by 70.1
main drive into eng hall    by 52.4
main drive into east range  by 41.8
main drive into reshall     by 20.0
forecourt spur into library by 77.9  (still pointing at reshall's OLD site)
```

Control points re-solved against every footprint — the curve bows outside its control polygon, which is how eyeballed points went wrong — iterated automatically until every kerb clears every wall. The forecourt spur now serves the residence hall where it actually stands.

**"the screen goes in and out of black" / "the quad near the chapel is unwalkable"** — walker collision radius 6, buttress piers proud of every lancet facade by 5, near plane 2 ahead of the eye: hugging a wall put the near plane *inside* the piers, and the north ring runs flush against the flanker faces, so walking it strobed black. `r = 10` keeps the camera clear of the deepest relief; the gate arch keeps a 16-unit corridor, the tightest open walk 28.

**CI**: smoke gains `no road runs into a building` — every drive sampled along its own curve against every collider via a new `__drives` hook. Walks excluded by design (the south walk threads the gate arch on purpose).

Cache `pembroke-v96`.


---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_