### PR TITLE
Stone is not metal: sanitize Drosdick Hall's materials on arrival

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -38,7 +38,13 @@ jobs:
     # having pushed over it. Raised with room rather than to the line,
     # so the next body added does not cost an evening working out why a
     # green suite went red without a failing check in it.
-    timeout-minutes: 35
+    #
+    # And again: the author's cathedral (355k tris) and Drosdick Hall
+    # (300k more, 24MB of textures) joined the campus and the drive
+    # crept from 24 minutes through 32 to a kill at 35 — the exact
+    # failure the paragraph above describes, suffered a second time by
+    # the timeout it set. Same rule, room rather than the line.
+    timeout-minutes: 50
     steps:
       - uses: actions/checkout@v4
 

--- a/index.html
+++ b/index.html
@@ -1928,7 +1928,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v101";
+const BUILD = "pembroke-v102";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -3356,6 +3356,29 @@ BUILDINGS.forEach(spec => {
     ["assets/drosdick_hall.glb", {
       plane: [865, 250], height: 169, maxFoot: [380, 380], sink: 1.5,
       onLoaded: (root) => {
+        /* The chapel's lesson, applied on arrival this time: the
+           export leaves metallicFactor at its glTF default of 1.0 and
+           carries a metallic-roughness texture that dips toward zero
+           — a mirror-metal lobe whose GGX math goes NaN, and one NaN
+           pixel through the bloom mip chain blacks out the whole
+           canvas (measured here on the day the hall landed, as an
+           all-black aerial). Stone is not metal: one plain material,
+           palette texture carrying the look, matte and NaN-proof. */
+        const rebuilt = new Map();
+        root.traverse(o => {
+          const m = o.material;
+          if (!o.isMesh || !m) return;
+          let std = rebuilt.get(m);
+          if (!std){
+            std = new THREE.MeshStandardMaterial({
+              map: m.map || null, color: m.color.clone(),
+              normalMap: m.normalMap || null,
+              roughness: 0.88, metalness: 0,
+              side: m.side });
+            rebuilt.set(m, std);
+          }
+          o.material = std;
+        });
         if (hallGroups.eng) hallGroups.eng.add(root);
         window.__drosdickHallIn = true;
       } }],

--- a/sw.js
+++ b/sw.js
@@ -32,7 +32,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v101";
+const VERSION = "pembroke-v102";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 


### PR DESCRIPTION
Field report on v101, with video: "screen flickers black" — the world below the skyline rendering black in day view on the Adreno phone, and the same all-black day canvas reproduced in the render probe here the moment the hall landed.

Cause: `drosdick_hall.glb` leaves `metallicFactor` at its glTF default of **1.0** and carries a metallic-roughness texture that dips toward zero — a mirror-metal specular lobe whose GGX math goes NaN, the exact failure the cathedral shipped with in v98 and was cured of in v99. Same cure here, applied in `onLoaded` before the model enters the world: every material rebuilt as a plain `MeshStandardMaterial` — palette texture and normal map kept, metalness 0, roughness 0.88, one rebuilt material per source material.

Verifying with the day-render probe (campus in day mode with the hall standing); merging on green.

Cache bumped to **pembroke-v102**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_