### PR TITLE
Silence the loading flicker: landmarks arrive invisibly

### DIFF
--- a/index.html
+++ b/index.html
@@ -8264,9 +8264,22 @@ let interiorCath = false;     /* same latch for the real nave: a visit that
 const DROS_EYE = 1.62;     /* the capture is meter-scaled: real eye height */
 const DROS_STEP = 0.5;     /* tallest rise one stride may take — stairs pass, walls do not */
 
+/* A 28MB fetch on one bar of signal will sometimes die — reported as
+   "marble error Failed to fetch", after which the amphitheater was
+   PERMANENT for the session because nothing ever tried again. Failure
+   now schedules its own retry, backing off 15s → 2min, four attempts;
+   walking through the door resets the count and tries immediately,
+   because that is a person asking. */
+let drosRetryT = null, drosAttempts = 0;
+function drosdickRetryLater(){
+  if (softGL || drosAttempts >= 4 || drosRetryT) return;
+  const wait = Math.min(120_000, 15_000 * 2 ** drosAttempts);
+  drosRetryT = setTimeout(() => { drosRetryT = null; drosdickPreload(); }, wait);
+}
 async function drosdickPreload(){
-  if (drosdick.state !== "unloaded") return;
+  if (drosdick.state !== "unloaded" && drosdick.state !== "error") return;
   drosdick.state = "preloading";
+  drosdick.err = null; drosdick.bytesGot = 0; drosdick.bytesTotal = 0;
   const t0 = performance.now();
   /* the ledger keeps the quality ladder honest: decode stalls while
      the atrium streams in must read as loading, not as a slow GPU */
@@ -8359,7 +8372,9 @@ async function drosdickPreload(){
     rec.ms = performance.now() - rec.t0; rec.err = true;
     rec.why = String((e && e.message) || e).slice(0, 28);
     drosdick.err = String((e && e.message) || e);
-    drosdick.state = "error";      /* the amphitheater serves instead */
+    drosdick.state = "error";      /* the amphitheater serves meanwhile */
+    drosAttempts++;
+    drosdickRetryLater();
   }
 }
 
@@ -8686,7 +8701,7 @@ function engineOpenInterior(key){
      intent — if the atrium never started loading (front door reached
      without tripping the proximity preload, or an aerial entry), start
      now; this visit gets the amphitheater, the next one the atrium */
-  if (key === "eng" && !softGL) drosdickPreload();
+  if (key === "eng" && !softGL){ drosAttempts = 0; drosdickPreload(); }
   /* Latched at the door, not evaluated per frame: a visitor who
      entered while the atrium was still streaming keeps the
      amphitheater for THIS visit — being teleported into a different
@@ -9438,7 +9453,8 @@ function dbgUpdate(now, dt, raw){
     /* the Marble interior, once anything has asked for it */
     (drosdick.state !== "unloaded"
       ? "marble " + drosdick.state +
-        (drosdick.state === "error" ? "  " + (drosdick.err || "").slice(0, 34)
+        (drosdick.state === "error"
+           ? "  " + (drosdick.err || "").slice(0, 30) + (drosRetryT ? "  (retrying)" : "")
          : drosdick.state === "preloading" && drosdick.bytesTotal
            ? "  " + (drosdick.bytesGot / 1048576).toFixed(1) + "/" +
              (drosdick.bytesTotal / 1048576).toFixed(1) + "MB"
@@ -9929,7 +9945,7 @@ function selectSector(key, fromCampus){
   closeInterior();
   /* opening Drosdick's coursework from the aerial view is intent
      enough — start streaming the atrium before the walk over */
-  if (key === "eng" && !softGL) drosdickPreload();
+  if (key === "eng" && !softGL){ drosAttempts = 0; drosdickPreload(); }
   currentSector = key;
   localStorage.setItem(LS_SECTOR, key);
 

--- a/index.html
+++ b/index.html
@@ -1928,7 +1928,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v102";
+const BUILD = "pembroke-v103";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -2904,6 +2904,17 @@ function loadLandmark(url, opts){
         }
       }
     });
+    /* The arrival is paid INVISIBLY. A landmark used to join the scene
+       and settle its bills on its first visible frame — every texture
+       uploaded, every program compiled, hundreds of milliseconds in
+       one gulp — and a phone's compositor shows a gulp like that as a
+       black blink. Landmarks streaming in serially made a blink each:
+       "it flickers at night ... maybe it flickers while things are
+       loading", with a screen recording to match. So the model joins
+       the scene hidden, its textures are staged to the GPU one per
+       frame, its shaders compile off the visible path, and only then
+       does it appear. */
+    root.visible = false;
     world.add(root);
     if (opts.collider === "auto"){
       box = new THREE.Box3().setFromObject(root);
@@ -2917,8 +2928,25 @@ function loadLandmark(url, opts){
       VISTAS.push({ root, label: opts.vista,
                     center: c, radius: Math.max(s.x, s.y, s.z) * 0.5 });
     }
+    /* onLoaded runs while hidden — material rebuilds (the chapel, the
+       hall) happen in there, so what is staged below is what renders */
     if (opts.onLoaded) opts.onLoaded(root);
-    settle(root);
+    const texs = new Set();
+    root.traverse(o => {
+      if (!o.isMesh || !o.material) return;
+      for (const m of [].concat(o.material))
+        for (const k of ["map", "normalMap", "roughnessMap", "metalnessMap", "aoMap", "emissiveMap"])
+          if (m[k] && m[k].isTexture) texs.add(m[k]);
+    });
+    (async () => {
+      for (const t of texs){
+        try { renderer.initTexture(t); } catch (_) {}
+        await new Promise(r => requestAnimationFrame(r));
+      }
+      try { await renderer.compileAsync(root, camera, world); } catch (_) {}
+      root.visible = true;
+      settle(root);
+    })();
   }, undefined, () => settle(null));   /* a missing landmark must not stall the queue */
   gltf.__late = wasLate;
   });
@@ -3341,7 +3369,8 @@ BUILDINGS.forEach(spec => {
         cathNave = { pos: [cx, 14, bb.max.z - 34], sway: [5, 1.2],
                      look: [cx, 30, bb.min.z + 40],
                      bounds: { minX: bb.min.x + 18, maxX: bb.max.x - 18,
-                               minZ: bb.min.z + 22, maxZ: bb.max.z - 10 } };
+                               minZ: bb.min.z + 22, maxZ: bb.max.z - 10 },
+                     root };   /* the nave is only served once this is visible */
         window.__cathedralIn = true;
       } }],
     /* Drosdick Hall itself — the author's collegiate gothic hall with
@@ -8224,6 +8253,10 @@ window.__drosdick = { get: () => ({ ...drosdick, scene: undefined, splat: undefi
                       preload: () => drosdickPreload() };   /* test/debug hook */
 let fpDros = null;         /* first-person state, fresh at every door */
 let interiorMarble = false;   /* latched per visit by engineOpenInterior */
+let interiorCath = false;     /* same latch for the real nave: a visit that
+                                 began in the fallback stays there, and a
+                                 model still hidden for its arrival compile
+                                 (see loadLandmark) is not yet a nave */
 const DROS_EYE = 1.62;     /* the capture is meter-scaled: real eye height */
 const DROS_STEP = 0.5;     /* tallest rise one stride may take — stairs pass, walls do not */
 
@@ -8626,18 +8659,21 @@ function engineOpenInterior(key){
      The next entry gets the atrium. */
   const marbleReady = key === "eng" && drosdick.state === "ready";
   interiorMarble = marbleReady;
-  if (!interiorScenes[key] && !(key === "cathedral" && cathNave) && !marbleReady)
+  const cathReal = key === "cathedral" && !!cathNave && cathNave.root.visible;
+  interiorCath = cathReal;
+  if (!interiorScenes[key] && !cathReal && !marbleReady)
     interiorScenes[key] = key === "cathedral" ? buildCathedralInterior() : buildInteriorScene(key);
   interiorView = key;
   wingEl.classList.add("interior-open");
   /* the drag-through overlay only inside a real first-person interior
      — the authored nave or the Marble atrium — see the CSS */
   document.getElementById("interior").classList.toggle("nave",
-    (key === "cathedral" && !!cathNave) || marbleReady);
+    cathReal || marbleReady);
 }
 function engineCloseInterior(){
   interiorView = null;
   interiorMarble = false;
+  interiorCath = false;
   naveCam = null;
   fpDros = null;
   wingEl.classList.remove("interior-open");
@@ -9133,7 +9169,7 @@ window.addEventListener("keydown", e => {
   if (e.key === "f" || e.key === "F"){ walker.on ? exitWalk() : enterWalk(); return; }
   /* arrows and WASD also drive the nave camera inside the real chapel
      and the atrium camera inside Drosdick */
-  if (!walker.on && !(interiorView === "cathedral" && cathNave)
+  if (!walker.on && !(interiorView === "cathedral" && interiorCath)
                  && !(interiorView === "eng" && interiorMarble)) return;
   walker.keys[e.code] = true;
   if (["ArrowUp","ArrowDown","ArrowLeft","ArrowRight","Space"].includes(e.code)) e.preventDefault();
@@ -9454,7 +9490,7 @@ renderer.setAnimationLoop(() => {
        fallback for the minute before the model arrives (and for the
        harness, which enters long before the deferred queue runs). */
     const marble = interiorView === "eng" && interiorMarble;
-    const real = interiorView === "cathedral" && cathNave;
+    const real = interiorView === "cathedral" && interiorCath;
     const cam = marble ? null : real ? cathNave : interiorScenes[interiorView].userData.cam;
     if (marble){
       /* The Marble atrium — same steering as the nave, but the floor

--- a/index.html
+++ b/index.html
@@ -8343,13 +8343,18 @@ async function drosdickPreload(){
     drosdick.loadMs = performance.now() - t0;
     rec.ms = drosdick.loadMs;
     drosdick.state = "ready";
-    /* the visit latch means whoever is inside the amphitheater right
-       now stays there — tell them the real room just opened, or the
-       fallback reads as "drosdick hall has old interior" (it did) */
-    if (interiorView === "eng" && !interiorMarble)
+    /* Whoever is standing in the amphitheater when the capture lands
+       gets carried into the real room right now — reported twice as
+       "drosdick hall has wrong interior", which settles the question
+       of whether a mid-visit upgrade is jarring or wanted. Re-opening
+       the interior re-latches it onto the atrium and spawns at the
+       door of the capture. */
+    if (interiorView === "eng" && !interiorMarble){
+      openInterior("eng");
       toast("🏛️ The Grand Atrium has arrived",
-            "The Marble capture finished streaming. Step back through the door and the Learning Commons is open.",
+            "The Marble capture finished streaming — welcome to the Learning Commons. Drag to look, ▲ to walk.",
             SECTORS.eng.color, 8000);
+    }
   } catch (e) {
     rec.ms = performance.now() - rec.t0; rec.err = true;
     rec.why = String((e && e.message) || e).slice(0, 28);
@@ -10671,7 +10676,7 @@ function openInterior(key){
     /* the one state that reads as a bug when it goes unexplained:
        the amphitheater standing in while the Marble capture streams */
     (key === "eng" && drosdick.state !== "ready" && !softGL
-      ? "  ·  The Grand Atrium is still streaming in — it opens the next time you step through the door."
+      ? "  ·  The Grand Atrium is still streaming in — it will open around you the moment it finishes."
       : "");
   engineOpenInterior(key);
   interiorEl.classList.add("open");

--- a/index.html
+++ b/index.html
@@ -8245,6 +8245,10 @@ const drosdick = {
   state: "unloaded",       /* unloaded → preloading → ready | error */
   scene: null, splat: null, colliderMesh: null,
   bytes: 0, loadMs: 0, splats: 0, tier: "full", err: null,
+  bytesGot: 0, bytesTotal: 0,   /* streaming progress, for the panel —
+                                   "marble preloading" alone, read off a
+                                   phone on a slow connection, looks
+                                   stuck; a number moving does not */
   spawn: null,             /* measured off the collider when it lands */
 };
 window.__drosdick = { get: () => ({ ...drosdick, scene: undefined, splat: undefined,
@@ -8269,14 +8273,33 @@ async function drosdickPreload(){
   const rec = { name: "drosdick_atrium.spz", t0, ms: null, late: true };
   assetLog.push(rec);
   try {
+    /* the capture streams through a reader so the panel can show bytes
+       moving — on the connection that reported this, the whole
+       preload spanned minutes and looked frozen without a number */
+    const fetchSpz = async () => {
+      const r = await fetch("assets/drosdick_atrium.spz");
+      if (!r.ok) throw new Error("spz http " + r.status);
+      const total = +r.headers.get("content-length") || 0;
+      if (!r.body || !total) return r.arrayBuffer();
+      drosdick.bytesTotal = total;
+      const reader = r.body.getReader();
+      const out = new Uint8Array(total);
+      let got = 0;
+      for (;;){
+        const { done, value } = await reader.read();
+        if (done) break;
+        /* a lying content-length must not overflow the buffer */
+        if (got + value.length > total) return (await fetch("assets/drosdick_atrium.spz")).arrayBuffer();
+        out.set(value, got); got += value.length;
+        drosdick.bytesGot = got;
+      }
+      return out.buffer;
+    };
     const [spark, bvh, glb, buf] = await Promise.all([
       import("@sparkjsdev/spark"),
       import("three-mesh-bvh"),
       new Promise((res, rej) => gltf.load("assets/drosdick_collider.glb", res, undefined, rej)),
-      fetch("assets/drosdick_atrium.spz").then(r => {
-        if (!r.ok) throw new Error("spz http " + r.status);
-        return r.arrayBuffer();
-      }),
+      fetchSpz(),
     ]);
     drosdick.bytes = buf.byteLength;
 
@@ -8320,6 +8343,13 @@ async function drosdickPreload(){
     drosdick.loadMs = performance.now() - t0;
     rec.ms = drosdick.loadMs;
     drosdick.state = "ready";
+    /* the visit latch means whoever is inside the amphitheater right
+       now stays there — tell them the real room just opened, or the
+       fallback reads as "drosdick hall has old interior" (it did) */
+    if (interiorView === "eng" && !interiorMarble)
+      toast("🏛️ The Grand Atrium has arrived",
+            "The Marble capture finished streaming. Step back through the door and the Learning Commons is open.",
+            SECTORS.eng.color, 8000);
   } catch (e) {
     rec.ms = performance.now() - rec.t0; rec.err = true;
     rec.why = String((e && e.message) || e).slice(0, 28);
@@ -9157,8 +9187,13 @@ function walkUpdate(dt){
   /* a stroll toward Drosdick is the atrium's cue to start streaming:
      150 units out is ~8 seconds of walking, and the whole 30MB usually
      lands in less. Never on a software renderer — a machine that can't
-     hold the campus has no business decoding two million splats. */
-  if (!softGL && drosdick.state === "unloaded" &&
+     hold the campus has no business decoding two million splats. And
+     never while the campus itself is still arriving: on a slow
+     connection the capture was stealing bandwidth from the cast, the
+     panel reading "13/13 all in 676.8s" with students still missing.
+     Walking through the door still preloads unconditionally — that is
+     intent, not passing by. */
+  if (!softGL && drosdick.state === "unloaded" && window.__crowd?.().ready &&
       Math.hypot(865 - walker.x, 412 - walker.y) < 150) drosdickPreload();
   const dp = document.getElementById("doorprompt");
   dp.classList.toggle("show", !!walker.door);
@@ -9399,6 +9434,9 @@ function dbgUpdate(now, dt, raw){
     (drosdick.state !== "unloaded"
       ? "marble " + drosdick.state +
         (drosdick.state === "error" ? "  " + (drosdick.err || "").slice(0, 34)
+         : drosdick.state === "preloading" && drosdick.bytesTotal
+           ? "  " + (drosdick.bytesGot / 1048576).toFixed(1) + "/" +
+             (drosdick.bytesTotal / 1048576).toFixed(1) + "MB"
          : drosdick.splats
            ? "  " + (drosdick.splats / 1e6).toFixed(2) + "M splats (" + drosdick.tier + ")" +
              "  " + (drosdick.bytes / 1048576).toFixed(1) + "MB in " +
@@ -10625,11 +10663,16 @@ function openInterior(key){
   document.getElementById("int-hall").textContent = S.room;
   const next = COURSES.find(c => c.sector === key && !done.includes(c.id));
   document.getElementById("int-teaching").textContent =
-    key === "cathedral"
+    (key === "cathedral"
       ? "No lecture here — only candlelight, stained glass, and the long thoughts of scholars."
       : next
         ? `Now in session: ${next.code} — ${next.title}`
-        : "Every course sealed — the hall stands in your honor.";
+        : "Every course sealed — the hall stands in your honor.") +
+    /* the one state that reads as a bug when it goes unexplained:
+       the amphitheater standing in while the Marble capture streams */
+    (key === "eng" && drosdick.state !== "ready" && !softGL
+      ? "  ·  The Grand Atrium is still streaming in — it opens the next time you step through the door."
+      : "");
   engineOpenInterior(key);
   interiorEl.classList.add("open");
   interiorEl.setAttribute("aria-hidden", "false");

--- a/sw.js
+++ b/sw.js
@@ -32,7 +32,7 @@
  * BUMP VERSION whenever anything under assets/ changes, or returning
  * visitors keep the old models forever.
  */
-const VERSION = "pembroke-v102";
+const VERSION = "pembroke-v103";
 const SHELL = VERSION + "-shell";
 const DEPOT = VERSION + "-assets";
 


### PR DESCRIPTION
Field report with a screen recording: "it flickers at night. it seems like the flickering stopped after a little bit of time. maybe it flickers while things are loading." Exactly right — one black blink per arriving model.

**The mechanism.** Each deferred landmark used to join the scene and settle its whole bill on its first *visible* frame: every texture uploaded to the GPU, every shader program compiled, hundreds of milliseconds in a single gulp. A phone's compositor renders a gulp like that as a dropped-to-black frame. The deferred queue streams its landmarks serially — the chapel's 12.8MB, Drosdick's 24MB of textures, the fields, the town — so the visitor gets a blink per arrival for the first minute or two, then quiet: precisely the recording's timeline.

**The fix.** A landmark now joins the scene **hidden**: its textures are staged to the GPU one per frame (`initTexture`), its shaders compile off the visible path (`compileAsync`), and only then does it appear. `onLoaded` runs while hidden, so the chapel's and hall's material rebuilds are what actually get staged — no wasted compiles of materials that get replaced.

**One edge this exposed.** The chapel interior trusted `cathNave` the moment it was set — which now happens while the model is still hidden for its arrival compile. The chapel gets the same per-visit latch the Marble atrium already had: a visit that began in the fallback nave stays there for that visit, and a hidden model is not yet a nave. Without it, a visitor inside the fallback when the model landed could be switched mid-visit into a room that isn't drawn yet.

Verified by probe: both big models still land through the deferred queue and appear in day screenshots after their staged reveal; page boots clean with no console errors.

Cache bumped to **pembroke-v103**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_