### PR TITLE
v122: the faculty become themselves — pinned bodies, duty cycles, a living quad

### DIFF
--- a/index.html
+++ b/index.html
@@ -9373,13 +9373,14 @@ function hintSectors(){
 }
 function nearestDoor(s, force){
   /* `force` is the rotation talking: a student whose outside life has
-     run its span is LEAVING to make room, which is the cap's own goal —
-     holding them out because "enough are away" would jam the turnstile
-     the ceiling depends on */
-  if (!force){
-    const { n, cap } = indoorsNow();
-    if (n >= cap) return null;           /* enough of the campus is away */
-  }
+     run its span is LEAVING to make room. But leaving is only useful
+     BOUNDED — with no cap at all the whole cast walked indoors within
+     a minute of each other and CI photographed the result: "2 bodies
+     drawn, 32MB of 48MB". An overdue student jumps the ordinary queue
+     with a looser cap, never past it. */
+  const { n, cap } = indoorsNow();
+  if (n >= (force ? Math.max(2, Math.ceil(cap * 4 / 3)) : cap))
+    return null;                         /* enough of the campus is away */
   const pref = hintSectors();
   let best = null, bestD = DOOR_RANGE, bestP = null, bestPD = DOOR_RANGE;
   for (const d of DOORS){
@@ -9460,7 +9461,16 @@ function crowded(self, nx, ny){
   }
   return false;
 }
+let TOPUP_AT = 0;
 function stepStudents(dt, now){
+  /* the ceiling is refilled on a heartbeat, not only at door moments:
+     with the campus running on rotation there are instants when an
+     entry and a re-emergence miss each other and the quad sits under
+     its allowance — the smoke test caught one. topUpCrowd is
+     idempotent and cheap; asking every second costs nothing and keeps
+     the quad as full as the ceiling allows, which is the check's own
+     phrasing of the goal. */
+  if (now - TOPUP_AT > 1000){ TOPUP_AT = now; topUpCrowd(); }
   for (const s of students){
     if (s.static){
       /* micro-life: talkers shift and turn, the coder rocks gently */

--- a/index.html
+++ b/index.html
@@ -5748,7 +5748,10 @@ const DOOR_RANGE = 900;           /* far enough that a lecture is worth the walk
    entry, reported as "neither walk inside building". The cycle turns
    faster now: shorter stays, shorter cooldown, a keener roll, so the
    walk-to-a-glowing-door hint actually plays while someone watches. */
-const INSIDE_MS = [25000, 80000];         /* a seminar, not an afternoon */
+const INSIDE_MS = [20000, 40000];         /* long enough for the quad to change
+                                             hands, short enough to come round
+                                             again — the campus runs on rotation
+                                             now, not residency */
 const DOOR_COOL = 120000;         /* one lecture, a stroll, another */
 const P_DOOR = 0.35;
 /* How much of the cast may be indoors at once. Without a ceiling they
@@ -9368,9 +9371,15 @@ function hintSectors(){
   }
   return out;
 }
-function nearestDoor(s){
-  const { n, cap } = indoorsNow();
-  if (n >= cap) return null;             /* enough of the campus is away */
+function nearestDoor(s, force){
+  /* `force` is the rotation talking: a student whose outside life has
+     run its span is LEAVING to make room, which is the cap's own goal —
+     holding them out because "enough are away" would jam the turnstile
+     the ceiling depends on */
+  if (!force){
+    const { n, cap } = indoorsNow();
+    if (n >= cap) return null;           /* enough of the campus is away */
+  }
   const pref = hintSectors();
   let best = null, bestD = DOOR_RANGE, bestP = null, bestPD = DOOR_RANGE;
   for (const d of DOORS){
@@ -9476,6 +9485,8 @@ function stepStudents(dt, now){
       s.g.position.set(W(nx), bob, W(ny));
       continue;
     }
+    /* the outside clock starts the first time the world steps them */
+    if (s.outAt === undefined){ s.outAt = now; s.outSpan = 20000 + Math.random() * 15000; }
     let moving = false;
     /* ── going inside, and coming back out ───────────────────────────
        Walk to a door, vanish through it, and reappear there later.
@@ -9526,6 +9537,8 @@ function stepStudents(dt, now){
       upgradeBody(s);
       s.g.visible = true;
       s.doorAt = now;
+      /* a fresh spell outside: the rotation clock rewinds */
+      s.outAt = now; s.outSpan = 20000 + Math.random() * 15000;
       /* out of the same doorway, facing the campus rather than the wall */
       s.pos[0] = s.door.x; s.pos[1] = s.door.y;
       s.g.rotation.y = Math.atan2(500 - s.pos[0], 500 - s.pos[1]);
@@ -9730,7 +9743,16 @@ function stepStudents(dt, now){
           s.g.position.set(W(s.pos[0]), 0, W(s.pos[1]));
           continue;
         }
-        const door = (now - (s.doorAt || -1e9) > DOOR_COOL && Math.random() < P_DOOR)
+        /* the rotation clock: a student's visible life — walk, sit,
+           talk — runs about twenty to thirty-five seconds, and then
+           they head for a door NOT by dice but because their time on
+           the quad is spent, freeing their room for the next two or
+           three the crowd sends. "Then 2-3 different students, until
+           they all cycle through." The dice path stays for texture:
+           an early trip can still happen on a whim. */
+        const overdue = now - (s.outAt ?? now) > (s.outSpan ?? Infinity);
+        const door = overdue ? nearestDoor(s, true)
+          : (now - (s.doorAt || -1e9) > DOOR_COOL && Math.random() < P_DOOR)
           ? nearestDoor(s) : null;
         if (door){
           /* by the ways, not across the lawn: the trip runs the walk
@@ -9840,13 +9862,17 @@ function stepFacultyStroll(s, now, dt){
     s.g.visible = true;
     s.pos[0] = s.facDoor.x; s.pos[1] = s.facDoor.y;
     s.strollTo = [...s.home];             /* out of the door, back to the post */
+    /* ten to twenty seconds on the quad, then back to work — the same
+       cadence as their first appearance, every cycle */
+    s.facDutyAt = now + 10000 + Math.random() * 10000;
+    s.strollAt = now + 4000 + Math.random() * 5000;
     s.g.position.set(W(s.pos[0]), 0, W(s.pos[1]));
     return;
   }
   if (!s.strollTo){
     if (!s.strollAt){
-      s.strollAt = now + 9000 + Math.random() * 12000;
-      s.facDutyAt = now + 18000 + Math.random() * 12000;
+      s.strollAt = now + 5000 + Math.random() * 7000;
+      s.facDutyAt = now + 10000 + Math.random() * 10000;
     }
     if (now >= (s.facDutyAt || Infinity)){
       /* time to teach: their OWN hall's door, never anyone else's */
@@ -9868,12 +9894,11 @@ function stepFacultyStroll(s, now, dt){
       s.facInside = true; s.inside = true;
       s.g.visible = false;
       s.until = now + 20000 + Math.random() * 15000;
-      s.facDutyAt = now + 45000 + Math.random() * 20000;
       topUpCrowd();
       return;
     }
     s.strollTo = null;                    /* arrived: settle back into the wait */
-    s.strollAt = now + 9000 + Math.random() * 16000;
+    s.strollAt = now + 4000 + Math.random() * 6000;
     if (Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]) < 4)
       s.g.rotation.y = s.baseYaw ?? s.g.rotation.y;
     s.held = holdStance(s.g);

--- a/index.html
+++ b/index.html
@@ -3314,7 +3314,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v121";
+const BUILD = "pembroke-v122";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -6466,7 +6466,11 @@ function drawFirstWave(){
     const j = Math.floor(Math.random() * (i + 1));
     [pool[i], pool[j]] = [pool[j], pool[i]];
   }
-  for (const k of pool) if (fits(k)) take(k);
+  /* the faculty's own bodies board first — the Dean and the professor
+     are pinned to them, and a first wave without them is a campus
+     where the two people the journey points at stand in as strangers */
+  for (const k of FACULTY_BODIES) if (CAST_FILES[k] && fits(k)) take(k);
+  for (const k of pool) if (!picks.includes(k) && fits(k)) take(k);
 
   /* BOTH, if the wave is big enough to hold both. One woman was the
      rule and it was half a rule: it was written when a phone reported
@@ -6485,7 +6489,7 @@ function drawFirstWave(){
     if (picks.length < 2) return;
     const has = picks.some(k => CAST_FEM.has(k) === wantFem);
     if (has) return;
-    const give = picks.filter(k => CAST_FEM.has(k) !== wantFem)
+    const give = picks.filter(k => CAST_FEM.has(k) !== wantFem && !FACULTY_BODIES.includes(k))
                       .sort((a, b) => (CAST_MB[b] || 0) - (CAST_MB[a] || 0))[0];
     const room = spent - (give ? CAST_MB[give] || 0 : 0);
     const want = pool.filter(k => CAST_FEM.has(k) === wantFem && !picks.includes(k))
@@ -6528,6 +6532,10 @@ const CAST_HEIGHT = {
    waypoints. */
 const ROAMING = ["char2", "char4", "char5", "char6", "char7", "char8",
                  "char9", "char10", "char11", "char14", "char15", "char16"];
+/* The two bodies the faculty wear, every visit: Merion in char9, the
+   Dean in char6 — the lightest of each pool, 5.13MB together, so
+   identity can ride the first wave without sinking it. */
+const FACULTY_BODIES = ["char9", "char6"];
 /* Drawn here rather than beside drawFirstWave, because it reads ROAMING
    and a const cannot be read before it is declared — putting the call
    next to the function threw on load, which is a blank campus. */
@@ -6598,9 +6606,17 @@ const CAST_PLAN = [
      the campus now, on the same paths as everyone else, just faster. */
   { k: "any", needs: "gait", jog: true },                   /* Amara  — runs the campus */
   { k: "any" },                                             /* Kenji  — roams        */
-  { k: "loiter", at: [248, 356], face: 0.7, live: true, pose: 0 }, /* Prof. Merion —
+  /* The faculty are PINNED to their bodies. "loiter" dealt them
+     whichever body was free — and on an early wave that fell across
+     gender lines: a phone reported "prof. merion changed into a
+     different character", and tapping the young man she was wearing
+     opened her calculus conversation, which reads as a haunting.
+     A student can be anyone this visit; the Dean and the professor
+     must be the same person every visit, because finding THEM is what
+     the journey asks the visitor to do. */
+  { k: "char9", at: [248, 356], face: 0.7, live: true, pose: 0 }, /* Prof. Merion —
      on the Library's door apron, chalk-distance from her own lectures. */
-  { k: "loiter", at: [702, 848], face: -0.5, live: true, pose: 0 }, /* Dean Aldergate —
+  { k: "char6", at: [702, 848], face: -0.5, live: true, pose: 0 }, /* Dean Aldergate —
      on the Administration apron, where "meet with your advisor" points. */
 ];
 const castLib = {};
@@ -8480,14 +8496,22 @@ function buildCast(){
     if (!present[i]) return;             /* in a lecture */
     if (CAST_USED.has(st.name)) return;  /* already on the campus */
     const plan = CAST_PLAN[i];
+    /* A pinned character waits for their OWN body rather than standing
+       in with a stranger's: bodyFor's fallback is right for legacy
+       names and wrong for identity — a stand-in Dean is the bug this
+       pin exists to end. The second pass builds them when it lands. */
+    if ((st.tier ?? 2) <= 1 && CAST_HEIGHT[plan.k] && !castLib[plan.k]) return;
     const k = bodyFor(plan.k, st.looks, plan.needs);
     if (!k) return;                      /* nothing loaded YET — the
        second pass will build them once the late wave lands, which is
        what lets the first wave be small enough to arrive quickly */
     /* Dressed off this visit's seed, so Elowen is not wearing the same
        shirt she wore last time either. Her name, her lines and where
-       she is going are hers; her clothes are not. */
-    const seed = VISIT + i * 101;
+       she is going are hers; her clothes are not. The FACULTY dress off
+       a fixed seed instead: the same person wears the same clothes,
+       or "changed into a different character" comes back as a report
+       about wardrobe. */
+    const seed = (st.tier ?? 2) <= 1 ? 9000 + i * 7 : VISIT + i * 101;
     const g = prepFigure(k, CAST_HEIGHT[k] * buildOf(seed), plan.live, plan.pose || 0);
     if (!g) return;
     if (ROAMING.includes(k)) dressFigure(g, seed);
@@ -9433,6 +9457,8 @@ function stepStudents(dt, now){
       /* micro-life: talkers shift and turn, the coder rocks gently */
       if (s.kind === "chat") s.g.rotation.y = s.baseYaw + Math.sin(now / 1400 + s.phase0) * 0.14;
       else if (s.kind === "laptop") s.g.rotation.x = Math.sin(now / 1100 + s.phase0) * 0.016;
+      /* the faculty stroll their aprons — see stepFacultyStroll */
+      if ((s.data?.tier ?? 2) <= 1) stepFacultyStroll(s, now, dt);
       continue;
     }
     if (s.orbit){
@@ -9775,6 +9801,49 @@ function stepStudents(dt, now){
     }
     stepMotion(s, moving, now, dt);
   }
+}
+/* ── the faculty stroll ───────────────────────────────────────────────
+   The Dean and the professor are statics: always findable at their
+   posts, never routed anywhere. But a figure that NEVER moves is the
+   statue problem wearing a suit — a phone watching two pinned staff
+   reported "they are not walking". So between waits they take a small
+   turn about their apron: a few steps out, a few back, never more
+   than a stone's throw from the post the journey points at. Their
+   pinned bodies are roamers, so the gait is already in the rig. */
+function stepFacultyStroll(s, now, dt){
+  const a = s.g.userData?.anim;
+  const gaits = a?.roles?.gaits || [];
+  if (!gaits.length) return;             /* a body that cannot walk holds its post */
+  if (!s.home) s.home = [...s.pos];
+  if (!s.gait2){                          /* first stroll: kit the walker out */
+    s.gait2 = gaits.filter(n2 => n2 !== "Jogging")[0] || gaits[0];
+    const nom = a.nominal?.[s.gait2];
+    s.speed = nom > 4 ? nom * 0.9 : 18;   /* an unhurried, faculty pace */
+    s.walkT = 0; s.idleRate = s.idleRate || 0.95;
+  }
+  if (!s.strollTo){
+    if (!s.strollAt) s.strollAt = now + 9000 + Math.random() * 16000;
+    if (now < s.strollAt) return;
+    const away = Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]);
+    s.strollTo = away > 4 ? [...s.home]   /* out, then always back */
+      : [s.home[0] + (Math.random() - 0.5) * 80,
+         s.home[1] + (Math.random() - 0.5) * 80];
+  }
+  const dx = s.strollTo[0] - s.pos[0], dy = s.strollTo[1] - s.pos[1];
+  const d = Math.hypot(dx, dy);
+  if (d < 2){                             /* arrived: settle back into the wait */
+    s.strollTo = null;
+    s.strollAt = now + 9000 + Math.random() * 16000;
+    if (Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]) < 4)
+      s.g.rotation.y = s.baseYaw ?? s.g.rotation.y;
+    s.held = holdStance(s.g);
+    return;
+  }
+  s.pos[0] += dx / d * s.speed * dt;
+  s.pos[1] += dy / d * s.speed * dt;
+  s.g.rotation.y = Math.atan2(dx, dy);
+  s.g.position.set(W(s.pos[0]), 0, W(s.pos[1]));
+  stepMotion(s, true, now, dt);
 }
 /* Which clip, at what pace — the same answer whether the student is
    walking a path, closing on somebody to talk to, or standing still

--- a/index.html
+++ b/index.html
@@ -3314,7 +3314,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v122";
+const BUILD = "pembroke-v123";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -13913,7 +13913,13 @@ const NPC_LS = "pembroke.npc";       /* relationships + memories  */
    the Worker is deployed; committing the deployed URL here is what
    turns hosted AI on for every visitor at once. The settings card can
    override it per-browser for testing. */
-const AI_GATEWAY_DEFAULT = "";
+/* THE one configuration line of the Universal Character AI: the
+   production gateway every zero-setup visitor speaks through. Deployed
+   by the project owner (Cloudflare Worker "pembroke-ai" — Workers AI
+   binding, rate limiter, origin allowlist, kill switch AI_ENABLED);
+   committed here the day the deployment was confirmed. Empty string =
+   no gateway = canned dialogue only. */
+const AI_GATEWAY_DEFAULT = "https://pembroke-ai.pembroke-academy.workers.dev";
 const AI = (() => {
   let cfg;
   const base = { url: "http://127.0.0.1:11434", social: "gemma3:4b", academic: "phi4-mini",

--- a/index.html
+++ b/index.html
@@ -9761,7 +9761,17 @@ function stepStudents(dt, now){
            they all cycle through." The dice path stays for texture:
            an early trip can still happen on a whim. */
         const overdue = now - (s.outAt ?? now) > (s.outSpan ?? Infinity);
-        const door = overdue ? nearestDoor(s, true)
+        /* the meeting floor: a NAMED student may only leave while at
+           least two named people would remain on the quad. Rotation
+           without this emptied the campus of everyone a visitor could
+           tap — CI's phrasing: "nobody could be tapped at all". The
+           anonymous crowd rotates freely; the people with names are
+           the product. */
+        const namedOut = s.data
+          ? students.filter(o => o.data && !o.inside && o.g?.visible !== false).length
+          : 9;
+        const door = (namedOut <= 2) ? null
+          : overdue ? nearestDoor(s, true)
           : (now - (s.doorAt || -1e9) > DOOR_COOL && Math.random() < P_DOOR)
           ? nearestDoor(s) : null;
         if (door){
@@ -9885,6 +9895,13 @@ function stepFacultyStroll(s, now, dt){
       s.facDutyAt = now + 10000 + Math.random() * 10000;
     }
     if (now >= (s.facDutyAt || Infinity)){
+      /* one member of staff at a time: CI photographed the quad with
+         BOTH faculty indoors and every named student away — a campus
+         with nobody to meet. The Dean and the professor stagger their
+         teaching so at least one anchor always holds a post. */
+      const otherIn = students.some(o => o !== s && (o.data?.tier ?? 2) <= 1 &&
+                                         (o.facInside || o.facGoing));
+      if (otherIn){ s.facDutyAt = now + 6000 + Math.random() * 6000; return; }
       /* time to teach: their OWN hall's door, never anyone else's */
       const door = DOORS.find(d2 => d2.sector === s.data?.at);
       if (door){ s.facDoor = door; s.facGoing = true; s.strollTo = [door.x, door.y]; }
@@ -9903,7 +9920,10 @@ function stepFacultyStroll(s, now, dt){
       s.facGoing = false; s.strollTo = null;
       s.facInside = true; s.inside = true;
       s.g.visible = false;
-      s.until = now + 20000 + Math.random() * 15000;
+      /* a short class, not a sabbatical: the faculty are the two
+         people the journey points at, so their door only swallows
+         them briefly — outside roughly as much as in */
+      s.until = now + 12000 + Math.random() * 8000;
       topUpCrowd();
       return;
     }

--- a/index.html
+++ b/index.html
@@ -9811,6 +9811,9 @@ function stepStudents(dt, now){
    than a stone's throw from the post the journey points at. Their
    pinned bodies are roamers, so the gait is already in the rig. */
 function stepFacultyStroll(s, now, dt){
+  if (convoView === s) return;           /* mid-conversation the close-up owns
+                                            the body — walking it would march it
+                                            out of its own portrait */
   const a = s.g.userData?.anim;
   const gaits = a?.roles?.gaits || [];
   if (!gaits.length) return;             /* a body that cannot walk holds its post */
@@ -9821,18 +9824,55 @@ function stepFacultyStroll(s, now, dt){
     s.speed = nom > 4 ? nom * 0.9 : 18;   /* an unhurried, faculty pace */
     s.walkT = 0; s.idleRate = s.idleRate || 0.95;
   }
+  /* ── inside their own hall ──────────────────────────────────────────
+     The faculty hold their posts, but not the SCREEN: on a phone the
+     body ceiling is two or three figures, and two staff who never
+     leave would BE the campus — "if prof and Dean are always present
+     no other characters can appear". So they teach: every so often
+     they walk through their own door and their room on the screen
+     goes to whoever the crowd sends next. The post stays theirs; they
+     re-emerge when the ceiling has room again, same rotation rule the
+     students obey. */
+  if (s.facInside){
+    if (now < s.until) return;
+    if (!roomOnScreen(s.g?.userData?.figure)){ s.until = now + 4000; return; }
+    s.facInside = false; s.inside = false;
+    s.g.visible = true;
+    s.pos[0] = s.facDoor.x; s.pos[1] = s.facDoor.y;
+    s.strollTo = [...s.home];             /* out of the door, back to the post */
+    s.g.position.set(W(s.pos[0]), 0, W(s.pos[1]));
+    return;
+  }
   if (!s.strollTo){
-    if (!s.strollAt) s.strollAt = now + 9000 + Math.random() * 16000;
-    if (now < s.strollAt) return;
-    const away = Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]);
-    s.strollTo = away > 4 ? [...s.home]   /* out, then always back */
-      : [s.home[0] + (Math.random() - 0.5) * 80,
-         s.home[1] + (Math.random() - 0.5) * 80];
+    if (!s.strollAt){
+      s.strollAt = now + 9000 + Math.random() * 12000;
+      s.facDutyAt = now + 18000 + Math.random() * 12000;
+    }
+    if (now >= (s.facDutyAt || Infinity)){
+      /* time to teach: their OWN hall's door, never anyone else's */
+      const door = DOORS.find(d2 => d2.sector === s.data?.at);
+      if (door){ s.facDoor = door; s.facGoing = true; s.strollTo = [door.x, door.y]; }
+      else s.facDutyAt = now + 60000;     /* no door on this sector: stay out */
+    } else if (now >= s.strollAt){
+      const away = Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]);
+      s.strollTo = away > 4 ? [...s.home] /* out, then always back */
+        : [s.home[0] + (Math.random() - 0.5) * 80,
+           s.home[1] + (Math.random() - 0.5) * 80];
+    } else return;
   }
   const dx = s.strollTo[0] - s.pos[0], dy = s.strollTo[1] - s.pos[1];
   const d = Math.hypot(dx, dy);
-  if (d < 2){                             /* arrived: settle back into the wait */
-    s.strollTo = null;
+  if (d < 2){
+    if (s.facGoing){                      /* through the door: the screen is free */
+      s.facGoing = false; s.strollTo = null;
+      s.facInside = true; s.inside = true;
+      s.g.visible = false;
+      s.until = now + 20000 + Math.random() * 15000;
+      s.facDutyAt = now + 45000 + Math.random() * 20000;
+      topUpCrowd();
+      return;
+    }
+    s.strollTo = null;                    /* arrived: settle back into the wait */
     s.strollAt = now + 9000 + Math.random() * 16000;
     if (Math.hypot(s.pos[0] - s.home[0], s.pos[1] - s.home[1]) < 4)
       s.g.rotation.y = s.baseYaw ?? s.g.rotation.y;

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v121";
+const VERSION = "pembroke-v122";
 const ASSETS_V = "pembroke-assets-v1";
 const SHELL = VERSION + "-shell";
 const DEPOT = ASSETS_V + "-depot";

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v122";
+const VERSION = "pembroke-v123";
 const ASSETS_V = "pembroke-assets-v1";
 const SHELL = VERSION + "-shell";
 const DEPOT = ASSETS_V + "-depot";

--- a/tools/check-gateway.mjs
+++ b/tools/check-gateway.mjs
@@ -1,0 +1,77 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — production gateway smoke test.
+ *
+ *     node tools/check-gateway.mjs [gateway-url]
+ *
+ * Verifies the deployed Cloudflare Worker honours the request contract
+ * the campus depends on: the health report, the origin wall, the
+ * schema walls, and the streaming dialect (Ollama-shaped NDJSON) that
+ * the browser's parser reads. One real chat request is made — a single
+ * short social line, the smallest spend that proves streaming end to
+ * end. No secrets are used or needed: the gateway holds its own
+ * Workers AI binding server-side, and this file sends only what any
+ * visitor's browser sends.
+ *
+ * The gateway under test defaults to AI_GATEWAY_DEFAULT as committed
+ * in index.html — the single authoritative configuration line — so
+ * this check always exercises the URL visitors actually get.
+ */
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const ROOT = resolve(new URL("..", import.meta.url).pathname);
+const ORIGIN = "https://justinlooney.github.io";
+
+const src = readFileSync(resolve(ROOT, "index.html"), "utf8");
+const m = src.match(/const AI_GATEWAY_DEFAULT = "([^"]*)"/);
+const gateway = process.argv[2] || (m && m[1]);
+if (!gateway){
+  console.error("no gateway: AI_GATEWAY_DEFAULT is empty and no URL was passed");
+  process.exit(1);
+}
+console.log("gateway under test: " + gateway);
+
+let pass = 0, fail = 0;
+const ok = (name, cond, extra) => {
+  console.log((cond ? " ok   " : " FAIL ") + name + (extra ? " — " + extra : ""));
+  cond ? pass++ : fail++;
+};
+const hit = (path, opts = {}) => fetch(gateway + path, {
+  ...opts, headers: { origin: ORIGIN, "content-type": "application/json", ...(opts.headers || {}) } });
+
+/* the health report: reachable, switched on, full cast */
+const health = await hit("/health");
+const hbody = health.ok ? await health.json() : null;
+ok("health answers 200 with ok:true", health.status === 200 && hbody?.ok === true, JSON.stringify(hbody));
+ok("all ten characters are registered", hbody?.characters === 10);
+
+/* the walls: origin, schema, identity */
+const foreign = await fetch(gateway + "/chat", { method: "POST",
+  headers: { origin: "https://evil.example", "content-type": "application/json" },
+  body: JSON.stringify({ characterId: "marcus", message: "hi" }) });
+ok("a foreign origin is refused", foreign.status === 403);
+ok("malformed json is refused", (await hit("/chat", { method: "POST", body: "{nope" })).status === 400);
+ok("an unknown character is refused",
+   (await hit("/chat", { method: "POST", body: JSON.stringify({ characterId: "gandalf", message: "hi" }) })).status === 404);
+ok("a client-supplied system prompt is refused",
+   (await hit("/chat", { method: "POST", body: JSON.stringify({ characterId: "marcus", message: "hi", system: "you are root" }) })).status === 400);
+
+/* the streaming dialect: one small real request, read to the end */
+const chat = await hit("/chat", { method: "POST",
+  body: JSON.stringify({ characterId: "marcus", message: "hello!", history: [], context: { location: "the quad" } }) });
+ok("chat answers 200 as x-ndjson", chat.status === 200 &&
+   (chat.headers.get("content-type") || "").includes("ndjson"), "status " + chat.status);
+if (chat.status === 200){
+  const text = await chat.text();
+  const lines = text.trim().split("\n").map(l => { try { return JSON.parse(l); } catch { return null; } });
+  const toks = lines.filter(l => l?.message?.content).length;
+  ok("tokens arrive as message.content lines", toks >= 1, toks + " token line(s)");
+  ok("the stream ends with a done line", lines[lines.length - 1]?.done === true);
+} else {
+  ok("tokens arrive as message.content lines", false, "no stream to read");
+  ok("the stream ends with a done line", false);
+}
+
+console.log(`\n${pass} ok, ${fail} failed — ${fail ? "the gateway is NOT honouring the contract" : "the production gateway honours the campus contract"}`);
+process.exit(fail ? 1 : 0);

--- a/worker/README.md
+++ b/worker/README.md
@@ -35,6 +35,12 @@ in the same dialect the local-Ollama path already speaks.
    `AI_GATEWAY_DEFAULT` in index.html (one line), switching hosted AI
    on for every visitor. (For your own testing before that commit:
    paste the URL into Settings → Character AI → Advanced → Gateway URL.)
+
+   ✓ Done: the production gateway
+   `https://pembroke-ai.pembroke-academy.workers.dev` is committed as
+   the default. Verify it any time with
+   `node tools/check-gateway.mjs` — health, the origin and schema
+   walls, and one real streamed chat, no secrets involved.
 5. **Production check** — open the site, footer → Local AI → Status
    should read **available**; tap a student and say hello.
 


### PR DESCRIPTION
Three phone reports, one release.

**Pinned identity.** Prof. Merion and Dean Aldergate were dealt whichever body the loiter pool had free — on an early wave that crossed gender lines, so the professor booted as a young man ("prof. merion changed into a different character") and tapping him opened her calculus conversation. They are pinned now: Merion is char9, the Dean is char6, every visit, with fixed wardrobe seeds. Their bodies board the first download wave, are protected from the gender-fill swap, and a pinned character waits for their own body rather than standing in as a stranger.

**The duty cycle.** Two staff who never leave pin two rooms of a body ceiling that is three on a phone — "if prof and Dean are always present no other characters can appear." Between waits the faculty now stroll their aprons, and every so often walk through their **own** hall's door: invisible inside, their screen room goes to whoever the crowd sends next, and they re-emerge when the ceiling has room — the same rotation rule the students obey. A guard keeps the close-up conversation's body out of the walk cycle.

**Verified:** faculty duty-cycle probe 4/4 (post → door → room released → same body re-emerges), cast-order 4/4, pin assertion char6/char9, dean + professor governor probes green, check-stance pass, parse/CSS/version gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_