### PR TITLE
v130: a figure built before it was taught stands in its bind pose

### DIFF
--- a/index.html
+++ b/index.html
@@ -12247,11 +12247,23 @@ function dbgUpdate(now, dt, raw){
     (fps < 10 ? "       SLOW MOTION: the campus runs at " +
                 (fps / 10).toFixed(2) + "x real time below 10fps\n" : "") +
     "gpu    " + ((glInfo || "unknown").slice(0, 30)) + "\n" +
+    /* What is RUNNING, not what is attached. The arrival preset silences
+       ssao and bloom with .enabled and stops the shadow pass by freezing
+       autoUpdate — none of which removes a pass or clears
+       shadowMap.enabled, so this line went on reporting "ssao+bloom" and
+       "shadows 3072" while neither was costing a frame. Photographed on
+       a phone with the preset plainly working: the panel under-reported
+       its own fix, in the release whose subject is a panel that tells
+       the truth about the load. */
     "post   " + (softGL ? "reduced (soft GL)"
-                        : [ssao && "ssao", composer.passes.includes(bloom) && "bloom",
+                        : [ssao && ssao.enabled && "ssao",
+                           composer.passes.includes(bloom) && bloom.enabled && "bloom",
                            !q.has("nosmaa") && "smaa"].filter(Boolean).join("+") || "none") +
       "   dpr " + renderer.getPixelRatio() +
-      (renderer.shadowMap.enabled ? "  shadows " + sun.shadow.mapSize.x : "  no shadows") +
+      (renderer.shadowMap.enabled
+        ? (renderer.shadowMap.autoUpdate ? "  shadows " + sun.shadow.mapSize.x
+                                         : "  shadows held")
+        : "  no shadows") +
       (rung ? "\n       quality rung " + rung + "/" + LADDER.length +
               " — given up to hold " + FPS_WANT + "fps" : "") + "\n" +
     /* Why the ladder is where it is, and what the screen lost getting

--- a/index.html
+++ b/index.html
@@ -3314,7 +3314,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v129";
+const BUILD = "pembroke-v130";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -7369,6 +7369,51 @@ function prepFigure(k, height, live, clipIx = 0){
   }
   return g2;
 }
+/* ── a figure built before it was taught ──────────────────────────────
+   prepFigure captures a body's clips at the moment it builds the
+   figure: the actions map, the nominal speeds and the roles are all
+   read once from castLib[k].animations. That is right for a body that
+   already has its clips, and silently wrong for one that does not yet.
+
+   Every authored body on this campus ships with NO animation at all —
+   they are lent everything — so "does not yet" is a real state with a
+   real duration, and a figure built inside it holds an empty actions
+   map for ever. Nothing to play, so holdStance finds neither a Talking
+   clip nor a gait and gives up, and the figure stands in the pose the
+   file was authored in: arms straight out. Reported from a phone as
+   "the professor is holding a t pose", and photographed as exactly
+   that.
+
+   It was a race rather than a rule, which is why it took the faculty
+   and not the students: instrumented over two runs, it took the
+   professor in one and the professor AND the Dean in the other. The
+   students are built later and had always been taught by then.
+
+   So a body that is taught something tells the figures already wearing
+   it. Actions the figure lacks are added to its own mixer, the roles
+   are recomputed, and anybody who was left standing in their bind pose
+   is given the stance they should have had. */
+function refreshClips(k){
+  const src = castLib[k];
+  if (!src) return;
+  for (const s of students){
+    const g = s.g;
+    if (!g || g.userData.figure !== k || !g.userData.anim) continue;
+    const a = g.userData.anim;
+    const h = g.userData.height || CAST_HEIGHT[k];
+    for (const c of src.animations){
+      if (a.actions[c.name]) continue;
+      a.actions[c.name] = a.mixer.clipAction(c);
+      a.nominal[c.name] = (c.userData.cycles || 1) * (0.68 * h) / Math.max(0.05, c.duration);
+    }
+    a.roles = rolesOf(k, src);
+    s.roles = a.roles;
+    /* Standing in the bind pose because there was nothing to stand in.
+       Only for the parked cast: a roamer picks its own clip on its next
+       step, and interrupting one mid-stride would be a visible snap. */
+    if (s.static && !a.current) s.held = holdStance(g);
+  }
+}
 /* ── lending a clip to somebody else's skeleton ───────────────────────
    Nobody on this campus could sit down onto anything. Walker's only
    clip that changes height is "Standing Up", and it begins at 0.01 of
@@ -8314,6 +8359,7 @@ function lendable(){
 }
 function lendSitDown(){
   const log = [];
+  const touched = new Set();
   for (const job of lendable()){
     if (!job.clip || !job.from) continue;
     const got = [], no = [];
@@ -8375,12 +8421,14 @@ function lendSitDown(){
          one of them is what anybody asked for. See seatRoles. */
       lent.userData.role = job.role || null;
       delete ROLE_CACHE[k];                     /* what this body can do just changed */
+      touched.add(k);
       got.push(k);
     }
     if (got.length || no.length)
       log.push(job.name + " -> " + (got.join(", ") || "nobody") +
                (no.length ? "; declined by " + no.join(", ") : ""));
   }
+  for (const k of touched) refreshClips(k);
   if (log.length) console.info("cast: lent " + log.join("  |  "));
 }
 

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v129";
+const VERSION = "pembroke-v130";
 /* v3 stays: this release ships no asset, so the model depot must not be
    re-versioned and the 39MB every returning visitor already holds must
    not be thrown away for a change that is entirely code. */


### PR DESCRIPTION
Reported from a phone: *"the professor is holding a t pose"* — and photographed as exactly that, arms straight out, standing on the quad.

## The cause

`prepFigure` captures a body's clips **at the moment it builds the figure**. The actions map, the nominal speeds and the roles are all read once from `castLib[k].animations`. That is right for a body that already has its clips, and silently wrong for one that does not yet.

Every authored body on this campus ships with **no animation at all** — they are lent everything — so "does not yet" is a real state with a real duration. A figure built inside it holds an empty actions map for ever: nothing to play, so `holdStance` finds neither a Talking clip nor a gait, gives up, and the figure keeps the pose the file was authored in.

**It is a race, not a rule**, which is why it took the faculty and not the students. Instrumented over two runs it took the professor in one, and the professor *and* the Dean in the other:

```
run A   Prof. Merion   = char18  talk=-  gaits=[]  playing=-
        Dean Aldergate = char17  talk=Talking  gaits=[Borrowed Walk,…]  playing=Borrowed Walk
run B   Prof. Merion   = char18  talk=-  gaits=[]  playing=-
        Dean Aldergate = char17  talk=-  gaits=[]  playing=-
```

The students are built later and had always been taught by then.

The file already knew about this hazard from the other side — *"Lend FIRST, then ask who can walk"* — but that guards the **question**, not the figures already built by the time it is answered.

## The fix

A body that is taught something now tells the figures already wearing it. Missing actions are added to the figure's own mixer, the roles are recomputed, and anybody left standing in their bind pose is given the stance they should have had.

Only the **parked** cast is restanced. A roamer picks its own clip on its next step, and interrupting one mid-stride would be a visible snap.

## Verified

Three consecutive runs, both faculty:

```
Prof. Merion   = char18  talk=Talking  gaits=[Borrowed Walk,Jogging]  playing=Borrowed Walk
Dean Aldergate = char17  talk=Talking  gaits=[Borrowed Walk,Female Walk 1,Jogging]  playing=Borrowed Walk
```

One of the three shows the repair path itself doing the work rather than the ordering happening to come out right — the Dean came back `held=live`, playing Talking.

`check-sw-version` v130, `check-css` clean, no page errors.

## Note on ordering

Opened alongside #61 (v129, the ways clearance) so both run CI in parallel. They touch different regions; whichever merges second needs only a version-number rebase, which I will handle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_