### PR TITLE
v131: the preset comes back, and the panel names the worst stall

### DIFF
--- a/index.html
+++ b/index.html
@@ -4421,15 +4421,13 @@ const assetLog = [];
    visit and nobody can be asked to reproduce that with a flag set. It
    costs one comparison a frame and at most 120 records. */
 const STALL_MS = 250;              /* below this the screen still moves */
-const trace = { stalls: [], lost: 0, worst: 0, frames: 0, t0: performance.now() };
+const trace = { stalls: [], lost: 0, worst: 0, worstAt: null, frames: 0, t0: performance.now() };
 function traceFrame(now, rawSec){
   trace.frames++;
   const ms = rawSec * 1000;
   if (ms < STALL_MS) return;
   trace.lost += ms;
-  trace.worst = Math.max(trace.worst, ms);
-  if (trace.stalls.length >= 120) return;   /* the shape is long since clear */
-  trace.stalls.push({
+  const rec = {
     at: Math.round(now - trace.t0),
     ms: Math.round(ms),
     /* Who was mid-parse. `late` marks the bodies fetched for the crowd,
@@ -4438,7 +4436,18 @@ function traceFrame(now, rawSec){
     decoding: assetLog.filter(a => a.ms == null).map(a => a.name + (a.late ? " (late)" : "")),
     rung, dpr: renderer.getPixelRatio(),
     why: LADDER_WHY,
-  });
+  };
+  /* The worst is kept as a RECORD, not as a number beside a list that
+     stops growing. Reading the figure from a running maximum and the
+     blame from the biggest surviving entry is two sources for one
+     fact, and past the cap they part company: the panel would print
+     "worst 5135ms" and then attribute whichever smaller stall happened
+     to be the largest one still in the list. A diagnostic that lies
+     confidently is worse than one that says nothing, and this release
+     is about that panel telling the truth. */
+  if (ms > trace.worst){ trace.worst = ms; trace.worstAt = rec; }
+  if (trace.stalls.length >= 120) return;   /* the shape is long since clear */
+  trace.stalls.push(rec);
 }
 /* test/debug hook: the whole trace, and a summary a person can read on
    the phone that produced it. */
@@ -12299,7 +12308,7 @@ function dbgUpdate(now, dt, raw){
        mattered, went unattributed. */
     (trace.stalls.length
       ? (() => {
-          const w = trace.stalls.reduce((a, b) => (b.ms > a.ms ? b : a));
+          const w = trace.worstAt;
           return "stalls " + trace.stalls.length + " frame(s), " + (trace.lost / 1000).toFixed(1) +
             "s lost, worst " + Math.round(trace.worst) + "ms\n" +
             "       worst at " + (w.at / 1000).toFixed(1) + "s " +

--- a/index.html
+++ b/index.html
@@ -3314,7 +3314,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v130";
+const BUILD = "pembroke-v131";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -3528,21 +3528,40 @@ const LADDER = [
                        shadowMap.enabled would have cost two full
                        material invalidations, one of them mid-load,
                        which is the fault wearing a different hat. */
-/* One way. The preset is an ARRIVAL phase, not a running policy: it
-   starts on, it ends once, and it does not come back.
- *
-   Driven purely by "is anything outstanding" it would re-engage every
-   time the site fetched something later — an interior, the atrium —
-   and each transition costs a resize, so a rule meant to stop the
-   screen flickering would have become a slower flicker of its own,
-   spread across the whole visit. After the arrival, changing quality
-   is the ladder's job and it has a measurement to do it on. */
-let loadPreset = false, presetDpr = 0, presetDone = false;
+/* It comes back. The first version did not, and the reasoning was that
+   re-engaging on every later fetch would cost a resize each time and
+   become a slower flicker of its own spread across the visit.
+
+   That was the wrong side of the trade, and the phone said so. The
+   atrium is a 27MB Gaussian capture that preloads when the visitor
+   walks within a hundred and fifty feet of Drosdick Hall — long after
+   the cast has landed and the preset has retired — and its decode was
+   measured on an Adreno at a single frame of 5135ms. Five seconds, at
+   pixel ratio 2 with ssao and 3072 shadow maps, because the one thing
+   that would have turned those down had decided its job was over.
+   "quality rung 5/5" is not the campus this fixes; "the black screen
+   still flickers some" is.
+
+   A resize is one frame. Weighed against five seconds it is not a
+   close question, and the flapping the one-way rule was protecting
+   against cannot happen anyway: `arriving` already carries a four
+   second settling window, so a burst of arrivals is one transition
+   down and one back up however many files it contains.
+
+   What the preset cannot do is make the decode itself shorter. A main
+   thread blocked for five seconds draws nothing whatever the pixel
+   ratio is. It makes the frames on either side of the block cheap,
+   which is worth having and is not the whole answer — see the note on
+   the atrium's own load. */
+let loadPreset = false, presetDpr = 0;
 function setLoadPreset(on){
-  if (on === loadPreset || (on && presetDone)) return;
-  if (!on) presetDone = true;
+  if (on === loadPreset) return;
   loadPreset = on;
   if (on){
+    /* Captured fresh each time. The ladder may have shed a pixel-ratio
+       rung since the last arrival, and restoring a number from before
+       that would hand back quality the ladder had already taken away on
+       an honest measurement. */
     presetDpr = renderer.getPixelRatio();
     if (presetDpr > 1) renderer.setPixelRatio(1);
     if (ssao) ssao.enabled = false;
@@ -12272,12 +12291,21 @@ function dbgUpdate(now, dt, raw){
        what the stalls are made of. Reading them together is the whole
        diagnosis. */
     "ladder " + (loadPreset ? "arrival preset on — " : "") + LADDER_WHY + "\n" +
+    /* The WORST stall and what it was blamed on, not the last one. The
+       last is merely the most recent and is usually the least
+       interesting: a phone came back with "5 frame(s), 6.6s lost,
+       worst 5135ms" and then named the suspects of a 300ms one that
+       happened to be latest — the five second frame, the only one that
+       mattered, went unattributed. */
     (trace.stalls.length
-      ? "stalls " + trace.stalls.length + " frame(s), " + (trace.lost / 1000).toFixed(1) +
-        "s lost, worst " + Math.round(trace.worst) + "ms\n" +
-        "       last at " + (trace.stalls[trace.stalls.length - 1].at / 1000).toFixed(1) + "s" +
-        (trace.stalls[trace.stalls.length - 1].decoding.length
-          ? " during " + trace.stalls[trace.stalls.length - 1].decoding[0] : "") + "\n"
+      ? (() => {
+          const w = trace.stalls.reduce((a, b) => (b.ms > a.ms ? b : a));
+          return "stalls " + trace.stalls.length + " frame(s), " + (trace.lost / 1000).toFixed(1) +
+            "s lost, worst " + Math.round(trace.worst) + "ms\n" +
+            "       worst at " + (w.at / 1000).toFixed(1) + "s " +
+            (w.decoding.length ? "during " + w.decoding.slice(0, 2).join(" + ")
+                               : "with nothing decoding") + "\n";
+        })()
       : "") +
     "draws  " + inf.render.calls + "   tris " + (inf.render.triangles / 1e6).toFixed(2) + "M\n" +
     "tex    " + inf.memory.textures + "   geo " + inf.memory.geometries + "\n" +

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v130";
+const VERSION = "pembroke-v131";
 /* v3 stays: this release ships no asset, so the model depot must not be
    re-versioned and the 39MB every returning visitor already holds must
    not be thrown away for a change that is entirely code. */


### PR DESCRIPTION
Field report on v128: *"it did black screen flicker. not as much as it was. but it did do it some."* The panel from that load explains both halves.

## What survived, and why

```
ladder measuring 60.0fps — nothing to give up
post   ssao+bloom+smaa   dpr 2   shadows 3072
stalls 5 frame(s), 6.6s lost, worst 5135ms
       last at 68.7s
marble ready  0.96M splats (half)  27.0MB
```

The preset had **already retired** — the ladder is measuring, quality is fully restored — and then a single frame took **5135ms**.

That is the atrium: a 27MB Gaussian capture fetched when the visitor walks within 150 feet of Drosdick Hall, long after the cast has landed. Five seconds of main-thread decode at pixel ratio 2, with ssao and 3072 shadow maps, because the one thing that would have turned those down had decided its job was over.

I made the preset one-way deliberately, reasoning that re-engaging on every later fetch costs a `resize()` each time and becomes a slower flicker spread across the visit. **That was the wrong side of the trade.** A resize is one frame; against five seconds it is not a close question. And the flapping the rule guarded against cannot happen anyway — `arriving` already carries a four-second settling window, so a burst of arrivals is one transition down and one back up however many files it contains.

The restored pixel ratio is captured fresh each time, so a rung the ladder has since shed on an honest measurement is not quietly handed back.

**What the preset cannot do is make the decode shorter.** A main thread blocked for five seconds draws nothing whatever the pixel ratio is. This makes the frames either side of the block cheap, which is worth having and is not the whole answer — the atrium's own cost is a separate problem, and one the author has since asked to remove entirely.

## The panel named the wrong stall

It reported the **last** stall, which is merely the most recent. The phone came back with `worst 5135ms` and then attributed a ~300ms frame that happened to be latest — so the five-second one, the only one that mattered, went unexplained. It names the **worst** now, with what was decoding during it.

## Verified

`tools/preset.probe.mjs` — **8/8**, including a new case for exactly this regression:

```
PASS: the preset is on while the campus is arriving
PASS: it drops the pixel ratio to 1
PASS: it stops the per-frame shadow pass
PASS: it silences the full-screen passes
PASS: it hands back once the cast has landed
PASS: shadows are live again
PASS: it comes back for a late arrival        ← new
PASS: no page errors
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_