### PR TITLE
v133: the quad takes the screen when you stand on it

### DIFF
--- a/index.html
+++ b/index.html
@@ -845,6 +845,45 @@ body.day .hall-tag{background:linear-gradient(180deg, rgba(24,30,44,.86), rgba(2
    utility classes on the element; the renderer is resized to match. */
 body.convo-open{overflow:hidden;}
 body.convo-open #stage{position:fixed;inset:0;z-index:31;}
+
+/* Walk mode does the same thing, one level up.
+   The same argument applies with more force: standing on the quad IS
+   the product, and it was running in a 560px band of a 13,000px
+   scrolling document — scroll down and the walker keeps walking
+   somewhere off screen while you read the course ledger.
+
+   The wing goes fixed, not #stage. Every part of the walking HUD —
+   the touchpad, the door prompt, the minimap, the quest chip, the
+   zoom readout — is a SIBLING of #stage inside the wing, so moving
+   the stage alone would peel the world off the controls and leave
+   them behind in the document. Moving their common parent takes the
+   whole instrument panel with it and needs no per-element rules.
+
+   inset:0 also overrides the section's own h-[560px] and lg:w-[52%]
+   without touching them, so leaving walk mode restores the layout by
+   dropping one class. */
+body.walkmode{overflow:hidden;}
+/* z-index 31 matches a conversation: over the page, under the toasts
+   at z-90 — "Boots on the quad" is how a first-time walker learns the
+   controls, and a mode that covered its own instructions would be a
+   poor trade. */
+body.walkmode #campus-wing{position:fixed;inset:0;width:auto;height:auto;z-index:31;}
+/* The masthead has to stop PAINTING, not merely lose the z-index race
+   — which it already loses. The canvas is transparent above the
+   horizon (the CSS .sky gradient behind it is the backdrop, by
+   design), so anything painted earlier shows straight through that
+   hole no matter what covers it in stacking order. Sticky at z-50, it
+   put a bar of ledger chrome across the top third of a phone's sky.
+   visibility, not display: the header keeps its box, so the document
+   does not shorten under a reader we are about to scroll back. */
+body.walkmode #topbar{visibility:hidden;}
+/* The arrival's "Begin — your Campus Visit" lives in the stage for its
+   first thirty seconds, and full-bleed it lands squarely on the phone
+   touchpad's ▶ — an unreachable button over the control it covers.
+   Its own code already says the world is the pitch and lets it bow out
+   when somebody starts exploring; walking IS that, so it bows out
+   here too rather than fighting the thumb pad for the same pixels. */
+.walkmode #arr-cta{display:none;}
 .convo-card{position:absolute;left:0;right:0;bottom:0;
   padding:1.1rem 1.4rem 1.3rem;
   background:linear-gradient(0deg, rgba(6,8,14,.94) 55%, rgba(6,8,14,.72) 80%, transparent);
@@ -3383,7 +3422,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v132";
+const BUILD = "pembroke-v133";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -11305,6 +11344,7 @@ addEventListener("keydown", (e) => {
    FIRST-PERSON WALK MODE — WebGL edition
    ══════════════════════════════════════════════════════════════════ */
 const wing = wingEl;
+let walkScrollY = 0;   /* where the page was when the quad took the screen */
 const DOORS = [
   { sector:"lib", x:260, y:326 }, { sector:"eng", x:865, y:412 },
   { sector:"sci", x:240, y:822 }, { sector:"adm", x:735, y:832 },
@@ -11373,7 +11413,17 @@ function enterWalk(){
   applyWalkZoom();
   applyFog();                           /* ground-level horizon, not the aerial one */
   wing.classList.add("walkmode");
+  /* Where the reader was before the quad took the screen. Locking the
+     body with overflow:hidden does not itself scroll the page, but a
+     fixed wing removes the tallest thing in the document, so the
+     browser clamps scrollY to the shorter page that remains — and
+     leaving walk mode would drop you somewhere you never were. */
+  walkScrollY = window.scrollY;
   document.body.classList.add("walkmode");  /* overlays outside the wing (orientation card) style off this */
+  /* the wing has just left the document and covers the window: the
+     renderer, the composer and the label layer all need the new shape,
+     same as a conversation does */
+  resize();
   /* from the ground the aerial anchors are deep in the sky — drop every
      nameplate to just over its roofline so the name captions the building */
   hallTags.forEach(t => t.position.y = t.userData.hover.walk);
@@ -11395,6 +11445,8 @@ function exitWalk(){
   applyFog();
   wing.classList.remove("walkmode");
   document.body.classList.remove("walkmode");
+  resize();                        /* and back into the page it goes */
+  window.scrollTo(0, walkScrollY); /* to the paragraph you left, not the top */
   hallTags.forEach(t => t.position.y = t.userData.hover.aerial);
   document.getElementById("walkbtn").textContent = "🎮";
   document.getElementById("doorprompt").classList.remove("show");

--- a/index.html
+++ b/index.html
@@ -11437,16 +11437,27 @@ function exitWalk(){
   walker.on = false;
   controls.enabled = true;
   renderer.domElement.style.touchAction = "";
-  aerialHome();
+  /* THE WING GOES BACK IN THE PAGE FIRST, and everything that measures
+     the stage happens after. standBack() reads the stage's aspect to
+     decide whether this is a narrow view that needs the camera pulled
+     back by PORTRAIT_K, and aerialPos() scales the whole home position
+     by it. Framing the aerial view while the wing was still fixed
+     inset:0 measured the WINDOW, not the column the camera is about to
+     live in — so a landscape laptop, whose window reads wide (k=1) but
+     whose restored 52% column reads narrow (k=1.5), landed a third too
+     close to the campus and stayed there, because nothing recomputes
+     the home position afterwards. Portrait phones hid it: both states
+     read narrow, so k came out the same either way. */
+  wing.classList.remove("walkmode");
+  document.body.classList.remove("walkmode");
+  resize();                        /* the stage has its own shape again */
+  window.scrollTo(0, walkScrollY); /* to the paragraph you left, not the top */
+  aerialHome();                    /* NOW the measurement is of the right box */
   controls.target.set(0, 30, 0);
   camera.rotation.set(0, 0, 0);
   camera.fov = fovFor(camera.aspect);       /* hand the fov back to the aerial view */
   camera.updateProjectionMatrix();
   applyFog();
-  wing.classList.remove("walkmode");
-  document.body.classList.remove("walkmode");
-  resize();                        /* and back into the page it goes */
-  window.scrollTo(0, walkScrollY); /* to the paragraph you left, not the top */
   hallTags.forEach(t => t.position.y = t.userData.hover.aerial);
   document.getElementById("walkbtn").textContent = "🎮";
   document.getElementById("doorprompt").classList.remove("show");
@@ -15232,6 +15243,12 @@ function closeInterior(){
 document.getElementById("int-leave").addEventListener("click", closeInterior);
 document.getElementById("int-courses").addEventListener("click", () => {
   closeInterior();
+  /* The ledger lives in the page, and walk mode has taken the page off
+     the screen — body overflow is hidden and the wing is fixed over
+     it, so both scrolls below are no-ops and the button read as dead:
+     the panel closed and you were left standing on the quad, no ledger
+     anywhere. Asking for the ledger is asking to leave the quad. */
+  if (walker.on) exitWalk();
   const ws = document.getElementById("workspace");
   ws.scrollTo({ top: 0, behavior: "smooth" });
   ws.scrollIntoView({ behavior: "smooth" });

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v132";
+const VERSION = "pembroke-v133";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -201,6 +201,21 @@ try {
   step("all twelve courses render", shelf.courses === 12, shelf.courses + " cards");
   step("registrar ledger reports", /\d/.test(shelf.total), JSON.stringify(shelf.total));
 
+  /* THE AERIAL STANDOFF, READ BEFORE ANY OF THIS TOUCHES THE VIEW.
+     It has to be taken here, in the aerial view at the suite's own
+     viewport, where the stage is the 52% column and reads WIDE so the
+     standback multiplier is 1. Read it any later — inside walk mode,
+     say — and it measures the fullscreen stage and the walker's own
+     camera, which is a different quantity entirely and makes the
+     comparison below pass against anything. */
+  const wide = await page.evaluate(() => {
+    const p = window.__app.camera.position, st = document.getElementById("stage");
+    return { far: Math.hypot(p.x, p.y, p.z), ratio: st.clientWidth / st.clientHeight };
+  });
+  step("the aerial standoff is read from a wide stage",
+       wide.ratio >= 0.85 && wide.far > 100,
+       "stage ratio " + wide.ratio.toFixed(2) + " · standoff " + Math.round(wide.far));
+
   /* walk mode: stand at the cathedral doors and expect the prompt */
   step("walk mode engages", await pressUntil("f", () => window.__walker.on === true));
 
@@ -249,13 +264,6 @@ try {
      re-frames the camera, so a baseline read after the resize would be
      the OLD viewport's position; that mistake is what this comment
      exists to stop the next person repeating. */
-  const wide = await page.evaluate(() => {
-    const p = window.__app.camera.position, st = document.getElementById("stage");
-    return { far: Math.hypot(p.x, p.y, p.z), ratio: st.clientWidth / st.clientHeight };
-  });
-  step("the suite's own viewport frames a wide stage", wide.ratio >= 0.85,
-       "stage ratio " + wide.ratio.toFixed(2) + " · standoff " + Math.round(wide.far));
-
   await page.evaluate(() => document.getElementById("walkbtn").click());   /* out of walk */
   await page.waitForTimeout(400);
   await page.setViewportSize({ width: 1024, height: 768 });

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -204,6 +204,72 @@ try {
   /* walk mode: stand at the cathedral doors and expect the prompt */
   step("walk mode engages", await pressUntil("f", () => window.__walker.on === true));
 
+  /* Walk mode takes the whole window and gives it back. Everything
+     below this point drives the campus through page.evaluate, which
+     never touches layout — so the full-bleed behaviour had no check at
+     all until a review pointed out that CI could not see it.
+
+     The exit framing is the assertion that earns its place. standBack()
+     reads the STAGE's aspect to decide whether a narrow view needs the
+     camera pulled back by PORTRAIT_K, so framing the aerial view while
+     the wing was still fullscreen measured the window instead of the
+     column the camera was about to live in — and nothing recomputes it
+     afterwards. Asserted as a value, not a class: the camera either
+     ends up where a fresh aerial view would put it, or it does not. */
+  const bleed = await page.evaluate(() => ({
+    wing: (() => { const r = document.getElementById("campus-wing").getBoundingClientRect();
+                   return { w: Math.round(r.width), h: Math.round(r.height),
+                            x: Math.round(r.x), y: Math.round(r.y) }; })(),
+    vw: window.innerWidth, vh: window.innerHeight,
+    locked: getComputedStyle(document.body).overflow === "hidden",
+    masthead: getComputedStyle(document.getElementById("topbar")).visibility,
+  }));
+  step("walking takes the whole window",
+       bleed.wing.x === 0 && bleed.wing.y === 0 &&
+       bleed.wing.w === bleed.vw && bleed.wing.h === bleed.vh,
+       `wing ${bleed.wing.w}x${bleed.wing.h} at ${bleed.wing.x},${bleed.wing.y} · viewport ${bleed.vw}x${bleed.vh}`);
+  step("the page is locked while walking", bleed.locked);
+  step("the masthead does not paint through the sky", bleed.masthead === "hidden",
+       "visibility " + bleed.masthead);
+
+  /* AT 1024x768 ON PURPOSE. The suite runs at 1280x800, where the
+     window (1.6) and the restored 52% column (0.92) both read WIDE, so
+     standBack() returns 1 either way and this bug is invisible — the
+     first version of this check sat at the suite's own viewport and
+     passed against the unfixed code. At 1024x768 the window reads wide
+     (1.33) and the column reads narrow (0.77), so the two disagree
+     about PORTRAIT_K and the mis-measurement shows: camera 1707 out
+     becomes 1138, a third too close, and nothing recomputes it. */
+  await page.evaluate(() => document.getElementById("walkbtn").click());
+  await page.waitForTimeout(400);
+  await page.setViewportSize({ width: 1024, height: 768 });
+  await page.waitForTimeout(600);
+  const framed = await page.evaluate(() => {
+    const p = window.__app.camera.position, st = document.getElementById("stage");
+    return { far: Math.hypot(p.x, p.y, p.z), stage: [st.clientWidth, st.clientHeight] };
+  });
+  await page.evaluate(() => document.getElementById("walkbtn").click());   /* in */
+  await page.waitForTimeout(500);
+  await page.evaluate(() => document.getElementById("walkbtn").click());   /* and out */
+  await page.waitForTimeout(700);
+  const framing = await page.evaluate(() => {
+    const p = window.__app.camera.position, st = document.getElementById("stage");
+    return { on: window.__walker.on, far: Math.hypot(p.x, p.y, p.z),
+             stage: [st.clientWidth, st.clientHeight] };
+  });
+  /* against the view this page framed for itself a moment earlier at
+     the same size — not a copied constant, which would only re-encode
+     AERIAL and PORTRAIT_K and stop meaning anything if either moved */
+  const drift = Math.abs(framing.far - framed.far) / Math.max(1, framed.far);
+  step("leaving walk mode frames the aerial view for the stage, not the window",
+       !framing.on && drift < 0.02,
+       `camera ${Math.round(framing.far)} out, framed at ${Math.round(framed.far)} before walking` +
+       ` · stage ${framing.stage.join("x")}`);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.waitForTimeout(600);
+
+  step("walk mode engages again", await pressUntil("f", () => window.__walker.on === true));
+
   /* The drop point, tested against every wall. v94 shipped with the
      walk-in point at 500,802 INSIDE a building that had been moved
      that morning — the player materialised trapped between buttress

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -234,37 +234,47 @@ try {
 
   /* AT 1024x768 ON PURPOSE. The suite runs at 1280x800, where the
      window (1.6) and the restored 52% column (0.92) both read WIDE, so
-     standBack() returns 1 either way and this bug is invisible — the
+     standBack() returns 1 either way and this bug cannot be seen — the
      first version of this check sat at the suite's own viewport and
      passed against the unfixed code. At 1024x768 the window reads wide
-     (1.33) and the column reads narrow (0.77), so the two disagree
-     about PORTRAIT_K and the mis-measurement shows: camera 1707 out
-     becomes 1138, a third too close, and nothing recomputes it. */
-  await page.evaluate(() => document.getElementById("walkbtn").click());
+     (1.33) while the column reads narrow (0.77), so the two disagree
+     about PORTRAIT_K and the mis-measurement shows.
+
+     Calibrated against this page rather than against copied constants:
+     `wide` is the standoff the suite's own viewport produces, where
+     the stage reads wide and the multiplier is 1. A narrow stage must
+     then stand meaningfully FURTHER back. Framing off the window
+     instead of the stage returns the wide standoff — which is the
+     failure, and is what the >1.2x test catches. Resizing alone never
+     re-frames the camera, so a baseline read after the resize would be
+     the OLD viewport's position; that mistake is what this comment
+     exists to stop the next person repeating. */
+  const wide = await page.evaluate(() => {
+    const p = window.__app.camera.position, st = document.getElementById("stage");
+    return { far: Math.hypot(p.x, p.y, p.z), ratio: st.clientWidth / st.clientHeight };
+  });
+  step("the suite's own viewport frames a wide stage", wide.ratio >= 0.85,
+       "stage ratio " + wide.ratio.toFixed(2) + " · standoff " + Math.round(wide.far));
+
+  await page.evaluate(() => document.getElementById("walkbtn").click());   /* out of walk */
   await page.waitForTimeout(400);
   await page.setViewportSize({ width: 1024, height: 768 });
   await page.waitForTimeout(600);
-  const framed = await page.evaluate(() => {
-    const p = window.__app.camera.position, st = document.getElementById("stage");
-    return { far: Math.hypot(p.x, p.y, p.z), stage: [st.clientWidth, st.clientHeight] };
-  });
-  await page.evaluate(() => document.getElementById("walkbtn").click());   /* in */
+  await page.evaluate(() => document.getElementById("walkbtn").click());   /* in  */
   await page.waitForTimeout(500);
   await page.evaluate(() => document.getElementById("walkbtn").click());   /* and out */
   await page.waitForTimeout(700);
   const framing = await page.evaluate(() => {
     const p = window.__app.camera.position, st = document.getElementById("stage");
     return { on: window.__walker.on, far: Math.hypot(p.x, p.y, p.z),
+             ratio: st.clientWidth / st.clientHeight,
              stage: [st.clientWidth, st.clientHeight] };
   });
-  /* against the view this page framed for itself a moment earlier at
-     the same size — not a copied constant, which would only re-encode
-     AERIAL and PORTRAIT_K and stop meaning anything if either moved */
-  const drift = Math.abs(framing.far - framed.far) / Math.max(1, framed.far);
   step("leaving walk mode frames the aerial view for the stage, not the window",
-       !framing.on && drift < 0.02,
-       `camera ${Math.round(framing.far)} out, framed at ${Math.round(framed.far)} before walking` +
-       ` · stage ${framing.stage.join("x")}`);
+       !framing.on && framing.ratio < 0.85 && framing.far > wide.far * 1.2,
+       `stage ${framing.stage.join("x")} ratio ${framing.ratio.toFixed(2)} · standoff ` +
+       `${Math.round(framing.far)}, wide standoff ${Math.round(wide.far)}` +
+       (framing.far <= wide.far * 1.2 ? "  (framed off the window, not the stage)" : ""));
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.waitForTimeout(600);
 


### PR DESCRIPTION
Closes #67.

Conversation mode has gone full-bleed and locked the page since it shipped. Walk mode never did — so the most differentiated thing the product does ran inside a 560px band of a 13,000px scrolling document on a phone, and inside the 52% column on a desktop. Scroll down and the walker kept walking somewhere off screen while you read the course ledger.

## The wing goes fixed, not the stage

The issue proposes copying the `convo-open` rule verbatim onto `#stage`. That would have peeled the world off its own controls: the thumb pad, door prompt, minimap, quest chip and zoom readout are **siblings** of `#stage` inside the wing, not children — which is why the issue then needs a separate "re-anchor the walk HUD" step. Moving their common parent does both at once and needs no per-element rules.

`inset:0` also overrides the section's `h-[560px]` and `lg:w-[52%]` without touching them, so leaving walk mode restores the layout by dropping one class.

## The masthead had to stop painting

It already lost the z-index race — `elementsFromPoint` at the top of the screen returns `#stage` frontmost. It kept painting anyway, because **the canvas is alpha-transparent above the horizon**: the CSS `.sky` gradient behind it is the backdrop, by design, so anything painted earlier shows straight through that hole regardless of what covers it in stacking order. Sticky at `z-50`, it laid a bar of ledger chrome across the top third of a phone's sky.

`visibility`, not `display` — the header keeps its box, so the document doesn't shorten under a reader we're about to scroll back.

## Scroll is remembered

Locking the body doesn't itself scroll the page, but a fixed wing removes the tallest thing in the document, so the browser clamps to the shorter page that remains. Leaving walk mode would have dropped you somewhere you'd never been. `enterWalk` records the position, `exitWalk` restores it.

## One item deliberately not implemented

The issue asks for `preventDefault` on the single-finger look path. **`touch-action: none` is the mechanism that stops a drag scrolling the page, and `enterWalk` has set it imperatively since it shipped** (`index.html`, in `enterWalk`; cleared in `exitWalk`). Preventing `pointermove` does not cancel scrolling. That line would read like a fix and do nothing, so it isn't here. The `{passive:false}` observation in the issue is correct, though — only the pinch `touchmove` carries it, and that's the handler that needs it.

## Also

The arrival CTA bows out while walking. Full-bleed it landed squarely on the thumb pad's ▶ — an unreachable button sitting on the control it covered. Its own code already says the world is the pitch and retires it when somebody starts exploring; walking is that.

## Verification

`tools/walkscreen.probe.mjs`, at 1280×800 and 390×844 with touch emulated, **entering from a page already scrolled 900px down** — the reported condition, not a fresh page where the wing happens to sit at the top anyway. Thirteen checks per viewport:

```
  ok   the page scrolls away from the campus to begin with  — scrollTop 900 · room 12549
  ok   the wing fills the viewport  — wing 390x844 at 0,0 · viewport 390x844
  ok   the renderer was resized to match  — 390x844
  ok   the body cannot scroll  — overflow hidden
  ok   the canvas owns its gestures  — touch-action none
  ok   every visible HUD control is on screen  — all in view
  ok   the masthead does not paint through the sky  — visibility hidden
  ok   but it keeps its box, so the document does not shorten  — height 137
  ok   a drag looks around  — pitch 0.504
  ok   and does not scroll the page  — scrollTop 900 (entered at 900)
  ok   leaving walk mode puts the wing back in the page  — position relative
  ok   the page scrolls again  — overflow hidden auto
  ok   and lands where the reader left it  — scrollTop 900 (was 900)
```

The desktop pass asserts the opposite precondition rather than skipping: that layout has only 12px of page scroll, because the workspace column scrolls inside itself — so there is nothing to lose and nothing to restore, and the probe says so instead of quietly passing.

Full smoke suite green locally, including every walk-mode check and the on-screen ceiling at 48MB/48MB. Photographed at both sizes.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_