### PR TITLE
CI: a wedged browser download costs minutes, not the whole job

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -13,6 +13,12 @@ concurrency:
   group: smoke-${{ github.ref }}
   cancel-in-progress: true
 
+# Named once. It keys the browser cache as well as pinning the install,
+# and a cache key that could drift from the version it describes would
+# hand back the wrong browser without saying so.
+env:
+  PW_VERSION: '1.56.1'
+
 jobs:
   # Changing a model without bumping the worker's VERSION strands every
   # returning visitor on the old one, and it is invisible to whoever made
@@ -52,10 +58,45 @@ jobs:
         with:
           node-version: '22'
 
+      # THE BROWSER IS CACHED AND THE STEPS ARE TIMED, and both halves
+      # of that matter.
+      #
+      # `npx playwright install` wedged four times in one afternoon —
+      # across both jobs, on unrelated pull requests. The process sits
+      # there, the job's whole budget drains behind it, and a fifty
+      # minute smoke job dies at fifty minutes having run no checks at
+      # all. GitHub reports that as "cancelled", which reads exactly
+      # like somebody pushed over it. Roughly 150 minutes of CI went to
+      # producing no signal whatsoever.
+      #
+      # The cache means the usual path never asks the CDN for a browser.
+      # The timeouts mean that when it does ask and the answer never
+      # comes, it costs minutes and fails as itself — a named step, not
+      # a mystery cancellation an hour later.
+      - name: Cache the browser
+        id: browser
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PW_VERSION }}
+
       - name: Install Playwright
-        run: |
-          npm install --no-save --no-audit --no-fund playwright@1.56.1
-          npx playwright install --with-deps chromium
+        timeout-minutes: 6
+        run: npm install --no-save --no-audit --no-fund playwright@${{ env.PW_VERSION }}
+
+      # Only on a miss. --with-deps also installs the system libraries
+      # the browser needs, which are apt packages rather than cached
+      # files — so a cache HIT still has to do that half, below.
+      - name: Fetch the browser
+        if: steps.browser.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
+
+      - name: System libraries for the cached browser
+        if: steps.browser.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
 
       # A minute, against a twenty-minute suite, for the one failure the
       # suite cannot see. An animation track addresses a node by name; if
@@ -114,10 +155,45 @@ jobs:
         with:
           node-version: '22'
 
+      # THE BROWSER IS CACHED AND THE STEPS ARE TIMED, and both halves
+      # of that matter.
+      #
+      # `npx playwright install` wedged four times in one afternoon —
+      # across both jobs, on unrelated pull requests. The process sits
+      # there, the job's whole budget drains behind it, and a fifty
+      # minute smoke job dies at fifty minutes having run no checks at
+      # all. GitHub reports that as "cancelled", which reads exactly
+      # like somebody pushed over it. Roughly 150 minutes of CI went to
+      # producing no signal whatsoever.
+      #
+      # The cache means the usual path never asks the CDN for a browser.
+      # The timeouts mean that when it does ask and the answer never
+      # comes, it costs minutes and fails as itself — a named step, not
+      # a mystery cancellation an hour later.
+      - name: Cache the browser
+        id: browser
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PW_VERSION }}
+
       - name: Install Playwright
-        run: |
-          npm install --no-save --no-audit --no-fund playwright@1.56.1
-          npx playwright install --with-deps chromium
+        timeout-minutes: 6
+        run: npm install --no-save --no-audit --no-fund playwright@${{ env.PW_VERSION }}
+
+      # Only on a miss. --with-deps also installs the system libraries
+      # the browser needs, which are apt packages rather than cached
+      # files — so a cache HIT still has to do that half, below.
+      - name: Fetch the browser
+        if: steps.browser.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
+
+      - name: System libraries for the cached browser
+        if: steps.browser.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
 
       # Students with no idle clip stand by holding one frame of their
       # walk, with breathe() adding a rise and a sway on top. That offset


### PR DESCRIPTION
`npx playwright install` wedged **four times in one afternoon**, across both jobs and unrelated pull requests. The process sits there, the job's entire budget drains behind it, and a fifty-minute smoke job dies at fifty minutes having run no checks at all:

```
Terminate orphan process: pid (2217) (npm exec playwright install --with-deps chromium)
```

GitHub reports that as **"cancelled"**, which reads exactly like somebody pushed over the run — so the first instinct is to re-run rather than investigate. It cost roughly 150 minutes of CI across #64, #91 and #63 and produced no signal whatsoever: not a failure, not a pass, nothing.

## Two changes, and both halves matter

**The browser is cached**, keyed on the Playwright version, so the usual path never asks the CDN for it. On a cache hit the system libraries still need installing — they're apt packages, not cached files — so that half runs separately.

**The steps are timed.** Caching makes the wedge rarer; it cannot make it impossible, and the *failure mode* is what made this expensive. A step timeout turns fifty wasted minutes into six, and turns a mystery cancellation into a named step that failed — the difference between "re-run and see" and knowing what went wrong.

| | before | after |
|---|---|---|
| wedge on a cache miss | 50 min, whole job, reported as cancelled | 8 min, named step, reported as failed |
| normal run | downloads the browser every time | restores from cache |
| version drift | pinned in two places independently | named once, keys the cache too |

The version is named once at the workflow level. It pins the install *and* keys the cache, and a key that could drift from the version it describes would hand back the wrong browser without saying so.

## What this does not change

No `BUILD` bump — nothing the site serves has changed, and bumping it would flush every returning visitor's shell for a CI edit. `check-sw-version.sh` passes on that basis.

The 50-minute job timeout and the 25-minute figures timeout are untouched; the comments above them record two earlier occasions when raising them was the right call, and this is not a third — the job budget was never the problem, a step with no budget of its own was.

## Verification

The workflow parses, and both jobs carry the same four steps in the same order with the guards attached:

```
--- smoke   timeout 50
    'Cache the browser'                        timeout=5
    'Install Playwright'                       timeout=6
    'Fetch the browser'                        timeout=8  if=cache-hit != 'true'
    'System libraries for the cached browser'  timeout=6  if=cache-hit == 'true'
--- figures timeout 25
    'Cache the browser'                        timeout=5
    'Install Playwright'                       timeout=6
    'Fetch the browser'                        timeout=8  if=cache-hit != 'true'
    'System libraries for the cached browser'  timeout=6  if=cache-hit == 'true'
```

This PR's own CI run is the first real test: it will populate the cache on the miss path, and the next PR should show the hit path.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_