### PR TITLE
v134: an unanswered question is not a wrong one

### DIFF
--- a/index.html
+++ b/index.html
@@ -12721,12 +12721,21 @@ function kcUnanswered(sec){
   });
   const nag = jbody.querySelector("#kc-nag");
   if (nag){
+    /* Every check carries two questions today, so "some but not all"
+       can only ever be one of them and the plural never appears. It
+       is written anyway: the day a check grows a third question is
+       not the day to discover the message says "Question 1 and 2
+       still needs an answer". */
+    const list = blanks.length > 1
+      ? blanks.slice(0, -1).join(", ") + " and " + blanks[blanks.length - 1]
+      : String(blanks[0]);
     nag.hidden = !blanks.length;
-    nag.textContent = blanks.length
-      ? (blanks.length === sec.qs.length
-          ? "Nothing is selected yet — answer before checking."
-          : `Question ${blanks.join(" and ")} still needs an answer.`)
-      : "";
+    nag.textContent = !blanks.length ? ""
+      : blanks.length === sec.qs.length
+        ? "Nothing is selected yet — answer before checking."
+        : blanks.length === 1
+          ? `Question ${list} still needs an answer.`
+          : `Questions ${list} still need an answer.`;
   }
   return blanks.length > 0;
 }
@@ -12740,10 +12749,11 @@ function stGradeKC(courseId, n, sec, S){
     const pick = jbody.querySelector(`input[name="q${qi}"]:checked`);
     const fs = jbody.querySelector(`[data-q="${qi}"]`);
     const why = fs.querySelector(".st-why");
-    /* !!pick, not pick: the guard above means it is never null here,
-       but `pick && …` yields the ELEMENT when the comparison is not
-       reached, and studyLog now refuses anything that is not a
-       boolean — a wrong answer must not become an unrecorded one */
+    /* !!pick, not pick: `pick && …` evaluates to pick itself when pick
+       is falsy — null here, not a boolean — and studyLog now refuses
+       anything that is not strictly true or false. The guard above
+       means that cannot happen from this call site, but a wrong answer
+       must not become an unrecorded one if it ever does. */
     const good = !!pick && +pick.value === q.a;
     if (good) right++;
     studyLog(courseId, n, "kc", good);

--- a/index.html
+++ b/index.html
@@ -1059,6 +1059,11 @@ body.panel-open #toasts{bottom:5.5rem;}
 .st-why{margin-top:.5rem;font-size:12px;color:#94a3b8;font-style:italic;}
 .st-q.right .st-why{color:#6ee7b7;}
 .st-q.wrong .st-why{color:#fca5a5;}
+/* "you have not answered yet" — deliberately not the wrong-answer red.
+   Nothing has been marked and nothing has been recorded; saying so in
+   the colour of a miss would be its own small lie. */
+.st-nag{margin-top:.6rem;font-size:12.5px;color:var(--brass);}
+.st-q.blank{border-color:rgba(212,175,106,.55);}
 /* the lesson player's blocks */
 .st-prof{margin:.4rem 0 .8rem;padding:.75rem .95rem;border-left:3px solid var(--brass);
   border-radius:.4rem;background:rgba(212,175,106,.07);font-size:13px;color:#cbd5e1;
@@ -3124,7 +3129,11 @@ function studyProgress(id){
   return { total: all.length, mastered: all.filter(s => st[s.n] === 2).length };
 }
 window.__study = { STUDY, progress: studyProgress, state: () => study,
-                   psetOf, psetState, psetGradedKeys, save: saveStudy };   /* test/debug hook */
+                   psetOf, psetState, psetGradedKeys, save: saveStudy,
+                   /* open a lecture directly: the panel is otherwise
+                      four clicks deep behind enrolment, and a check
+                      that has to enrol first is testing enrolment */
+                   openSection: (id, n) => jStudySection(id, n) };   /* test/debug hook */
 let done = loadDone();
 let currentSector = localStorage.getItem(LS_SECTOR) || "all";
 const byId = Object.fromEntries(COURSES.map(c => [c.id, c]));
@@ -3422,7 +3431,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v133";
+const BUILD = "pembroke-v134";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -12267,6 +12276,19 @@ function jStudy(courseId){
    verdict, when. Capped FIFO; the tutor reads SIGNALS from this,
    never raw answers. */
 function studyLog(courseId, n, kind, okAns){
+  /* A record of what a student got right and wrong is only worth
+     keeping if every entry means one of those two things. `ok ? 1 : 0`
+     will happily turn null — "they never answered" — into a miss
+     indistinguishable from a wrong answer, and that miss goes on to
+     become a "stumble" the professor teaches to. Refuse it: an entry
+     that cannot say which happened does not belong in the ledger, and
+     saying so on the console is how the next one gets found. */
+  if (typeof okAns !== "boolean"){
+    console.error("study: refusing to record a " + typeof okAns + " outcome for " +
+                  courseId + " " + n + " (" + kind + ") — an attempt is right or wrong, " +
+                  "and anything else is a bug in the caller, not a miss");
+    return;
+  }
   study[courseId] = study[courseId] || {};
   const log = study[courseId].log = study[courseId].log || [];
   log.push({ n, k: kind, ok: okAns ? 1 : 0, at: Date.now() });
@@ -12625,6 +12647,7 @@ function jLessonFull(courseId, n){
         </fieldset>`).join("")}
       <div class="flex items-center gap-3 mt-2 flex-wrap">
         <button type="submit" class="jcta" style="--c:${S.color}">Check my work</button>
+        <div class="st-nag" id="kc-nag" role="status" hidden></div>
         ${psetOf(courseId, n) ? `<button type="button" class="jlink" data-pset>Problem Set${psetCleared(courseId, n) && psetState(courseId, n).cleared ? " · cleared ✓" : ""}</button>` : ""}
         <button type="button" class="jlink" data-hw>Homework ${ext.hw ? `· best ${ext.hw[0]}/${ext.hw[1]}` : ""}</button>
         <button type="button" class="jlink" data-back>← all lectures</button>
@@ -12674,14 +12697,54 @@ function jLessonFull(courseId, n){
   });
 }
 
+/* ── an unanswered question is not a wrong one ────────────────────
+   Submitting a knowledge check with nothing selected used to mark
+   every question wrong, reveal every correct answer permanently, and
+   write a miss per question into the study record. The reveal alone
+   destroys the assessment — you cannot un-see the answer — but the
+   log entry is worse, because studySignals() groups misses into
+   "recent stumbles" and hands them to Prof. Merion as the thing to
+   teach to. One accidental submit had him working on a struggle that
+   never happened.
+
+   Shared by both lesson views on purpose: the full player and the
+   lite one carry separate graders (they diverge in what they record
+   and what they seal, which is its own issue), and a guard that only
+   one of them called would leave the reveal live in the other. */
+function kcUnanswered(sec){
+  const blanks = [];
+  sec.qs.forEach((q, qi) => {
+    const fs = jbody.querySelector(`[data-q="${qi}"]`);
+    const answered = !!jbody.querySelector(`input[name="q${qi}"]:checked`);
+    fs?.classList.toggle("blank", !answered);
+    if (!answered) blanks.push(qi + 1);
+  });
+  const nag = jbody.querySelector("#kc-nag");
+  if (nag){
+    nag.hidden = !blanks.length;
+    nag.textContent = blanks.length
+      ? (blanks.length === sec.qs.length
+          ? "Nothing is selected yet — answer before checking."
+          : `Question ${blanks.join(" and ")} still needs an answer.`)
+      : "";
+  }
+  return blanks.length > 0;
+}
+
 /* the knowledge-check marker, shared by both lesson views */
 function stGradeKC(courseId, n, sec, S){
+  /* nothing graded, nothing revealed, nothing recorded */
+  if (kcUnanswered(sec)) return;
   let right = 0;
   sec.qs.forEach((q, qi) => {
     const pick = jbody.querySelector(`input[name="q${qi}"]:checked`);
     const fs = jbody.querySelector(`[data-q="${qi}"]`);
     const why = fs.querySelector(".st-why");
-    const good = pick && +pick.value === q.a;
+    /* !!pick, not pick: the guard above means it is never null here,
+       but `pick && …` yields the ELEMENT when the comparison is not
+       reached, and studyLog now refuses anything that is not a
+       boolean — a wrong answer must not become an unrecorded one */
+    const good = !!pick && +pick.value === q.a;
     if (good) right++;
     studyLog(courseId, n, "kc", good);
     fs.classList.toggle("right", good);
@@ -13408,6 +13471,7 @@ function jStudySection(courseId, n){
         </fieldset>`).join("")}
       <div class="flex items-center gap-3 mt-2">
         <button type="submit" class="jcta" style="--c:${S.color}">Check my work</button>
+        <div class="st-nag" id="kc-nag" role="status" hidden></div>
         <button type="button" class="jlink" data-back>← all lectures</button>
       </div>
     </form>
@@ -13415,6 +13479,7 @@ function jStudySection(courseId, n){
   jbody.querySelector("[data-back]").addEventListener("click", () => jStudy(courseId));
   jbody.querySelector("#st-quiz").addEventListener("submit", (e) => {
     e.preventDefault();
+    if (kcUnanswered(sec)) return;   /* see kcUnanswered — same guard, both views */
     let right = 0;
     sec.qs.forEach((q, qi) => {
       const pick = jbody.querySelector(`input[name="q${qi}"]:checked`);

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v133";
+const VERSION = "pembroke-v134";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -226,8 +226,14 @@ try {
     if (!document.getElementById("st-quiz")) return { ready: false };
     submit();                                     /* nothing selected */
     await new Promise(r => setTimeout(r, 250));
+    const nag = document.getElementById("kc-nag");
     const blank = { logged: logged().length, revealed: revealed(), marked: marked(),
-                    named: document.getElementById("kc-nag")?.hidden === false };
+                    /* the TEXT, not merely the element's visibility — a
+                       step called "says which questions are missing"
+                       that only checks a hidden attribute is claiming
+                       more than it looked at */
+                    named: nag?.hidden === false ? (nag.textContent || "").trim() : "",
+                    flagged: document.querySelectorAll("#st-quiz .st-q.blank").length };
 
     document.querySelectorAll("#st-quiz [data-q]").forEach(fs => {
       const r = fs.querySelector("input[type=radio]");
@@ -253,7 +259,9 @@ try {
        kc.ready ? kc.blank.logged + " entr(ies) written" : "");
   step("an unanswered check reveals nothing", kc.ready && kc.blank.revealed === 0 && kc.blank.marked === 0,
        kc.ready ? kc.blank.revealed + " revealed, " + kc.blank.marked + " marked" : "");
-  step("and says which questions are missing", kc.ready && kc.blank.named);
+  step("and says which questions are missing",
+       kc.ready && /answer/i.test(kc.blank.named) && kc.blank.flagged >= 2,
+       kc.ready ? JSON.stringify(kc.blank.named) + " · " + kc.blank.flagged + " flagged" : "");
   step("a real attempt is still graded and recorded",
        kc.ready && kc.real.marked >= 2 && kc.real.revealed >= 2 && kc.real.logged >= 2,
        kc.ready ? kc.real.marked + " marked, " + kc.real.revealed + " revealed, " +

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -201,6 +201,56 @@ try {
   step("all twelve courses render", shelf.courses === 12, shelf.courses + " cards");
   step("registrar ledger reports", /\d/.test(shelf.total), JSON.stringify(shelf.total));
 
+  /* An unanswered knowledge check is not a wrong one. Submitting with
+     nothing selected used to mark every question wrong, reveal every
+     answer permanently, and write a miss per question into the study
+     record — and studySignals() hands those misses to Prof. Merion as
+     the stumbles to teach to, so one stray submit had him working on
+     a struggle that never happened.
+
+     Both halves are asserted. A guard that refused everything would
+     pass the first half on its own, and would be a worse bug than the
+     one it replaced. */
+  const kc = await page.evaluate(async () => {
+    const st = window.__study.state();
+    for (const k of Object.keys(st)) delete st[k];
+    window.__study.save();
+    window.__study.openSection("MATH201", "1.1");
+    await new Promise(r => setTimeout(r, 400));
+    const submit = () => document.querySelector("#st-quiz button[type=submit]").click();
+    const revealed = () => [...document.querySelectorAll("#st-quiz .st-why")]
+      .filter(e => !e.hidden && e.textContent.trim()).length;
+    const marked = () => document.querySelectorAll("#st-quiz .st-q.wrong, #st-quiz .st-q.right").length;
+    const logged = () => ((window.__study.state().MATH201 || {}).log || []);
+
+    if (!document.getElementById("st-quiz")) return { ready: false };
+    submit();                                     /* nothing selected */
+    await new Promise(r => setTimeout(r, 250));
+    const blank = { logged: logged().length, revealed: revealed(), marked: marked(),
+                    named: document.getElementById("kc-nag")?.hidden === false };
+
+    document.querySelectorAll("#st-quiz [data-q]").forEach(fs => {
+      const r = fs.querySelector("input[type=radio]");
+      if (r){ r.checked = true; r.dispatchEvent(new Event("change", { bubbles: true })); }
+    });
+    submit();                                     /* a real attempt */
+    await new Promise(r => setTimeout(r, 250));
+    const real = { logged: logged().length, revealed: revealed(), marked: marked(),
+                   clean: logged().every(e => e.ok === 0 || e.ok === 1) };
+    return { ready: true, blank, real };
+  });
+  step("the knowledge check opens", kc.ready);
+  step("an unanswered check records nothing", kc.ready && kc.blank.logged === 0,
+       kc.ready ? kc.blank.logged + " entr(ies) written" : "");
+  step("an unanswered check reveals nothing", kc.ready && kc.blank.revealed === 0 && kc.blank.marked === 0,
+       kc.ready ? kc.blank.revealed + " revealed, " + kc.blank.marked + " marked" : "");
+  step("and says which questions are missing", kc.ready && kc.blank.named);
+  step("a real attempt is still graded and recorded",
+       kc.ready && kc.real.marked >= 2 && kc.real.revealed >= 2 && kc.real.logged >= 2,
+       kc.ready ? kc.real.marked + " marked, " + kc.real.revealed + " revealed, " +
+                  kc.real.logged + " logged" : "");
+  step("every record entry says right or wrong, nothing else", kc.ready && kc.real.clean);
+
   /* THE AERIAL STANDOFF, READ BEFORE ANY OF THIS TOUCHES THE VIEW.
      It has to be taken here, in the aerial view at the suite's own
      viewport, where the stage is the 52% column and reads WIDE so the

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -237,7 +237,16 @@ try {
     await new Promise(r => setTimeout(r, 250));
     const real = { logged: logged().length, revealed: revealed(), marked: marked(),
                    clean: logged().every(e => e.ok === 0 || e.ok === 1) };
-    return { ready: true, blank, real };
+
+    /* PUT THE PAGE BACK. jOpen focuses the first control inside the
+       modal, so leaving it open traps the keyboard: the `f` that
+       enters walk mode never reaches the window handler, and every
+       check after this one fails for a reason that has nothing to do
+       with what it is testing. Seven of them did, once. */
+    document.querySelector("[data-jclose]")?.click();
+    await new Promise(r => setTimeout(r, 200));
+    const shut = !document.querySelector(".jmodal.open, #jmodal.open");
+    return { ready: true, blank, real, shut };
   });
   step("the knowledge check opens", kc.ready);
   step("an unanswered check records nothing", kc.ready && kc.blank.logged === 0,
@@ -250,6 +259,9 @@ try {
        kc.ready ? kc.real.marked + " marked, " + kc.real.revealed + " revealed, " +
                   kc.real.logged + " logged" : "");
   step("every record entry says right or wrong, nothing else", kc.ready && kc.real.clean);
+  /* asserted, not assumed: a check that quietly leaves a modal over
+     the page is worse than no check, because it fails the NEXT one */
+  step("the lecture panel is closed again", kc.ready && kc.shut);
 
   /* THE AERIAL STANDOFF, READ BEFORE ANY OF THIS TOUCHES THE VIEW.
      It has to be taken here, in the aerial view at the suite's own


### PR DESCRIPTION
Closes #65.

Submitting a knowledge check with nothing selected marked every question wrong, revealed every correct answer permanently, and wrote a miss per question into the study record.

The reveal alone destroys the assessment — you cannot un-see an answer — but the log entry is worse. `studySignals()` groups misses into "recent stumbles" and hands them to Prof. Merion as the thing to teach to, so one stray submit had him working on a struggle that never happened.

Reproduced before fixing, and the transcript matches the report exactly:

```
log       [{"n":"1.1","k":"kc","ok":0},{"n":"1.1","k":"kc","ok":0}]
revealed  "✗ 16 − 12 = 4." | "✗ One input, one output — the vertical…"
```

## Both surfaces, not one

There are **two** knowledge-check graders — the full lesson player and a lite view with its own inline copy. Only the first logs, so only the first corrupts the record; but both revealed the answers, and the reveal is the half that cannot be taken back. A guard wired into `stGradeKC` alone would have left the lite view quietly spoiling assessments.

They share `kcUnanswered()` now. The rest of the divergence between those two graders is left alone — it's a separate concern and belongs in its own change.

## The class, not just the instance

`studyLog` refuses a non-boolean outcome and says so on the console, as the issue suggested. `ok ? 1 : 0` will turn `null` — *"they never answered"* — into a miss indistinguishable from a wrong answer.

This is real defence in depth rather than theatre: the original expression yielded `null`, so the strict check alone would have blocked the record corruption even with no guard in place.

The prompt is brass, not the wrong-answer red. Nothing has been marked and nothing recorded; saying so in the colour of a miss would be its own small lie.

## Verification

In `tools/smoke.mjs`, not a gitignored probe — CI sees these. **Both halves are asserted**, because a guard that refused *everything* would pass the first half and be a worse bug than the one it replaces:

```
  ok   an unanswered check records nothing  — 0 entr(ies) written
  ok   an unanswered check reveals nothing  — 0 revealed, 0 marked
  ok   and says which questions are missing
  ok   a real attempt is still graded and recorded  — 2 marked, 2 revealed, 2 logged
  ok   every record entry says right or wrong, nothing else
  ok   the lecture panel is closed again
```

That last line is there because of a mistake worth recording. The first version of this block opened a lecture and never closed it — and `jOpen` focuses the first control inside the modal, so the keyboard stayed trapped there, the `f` that enters walk mode never reached the window handler, and **seven later checks failed** for reasons that had nothing to do with what any of them tested. All six of the new checks passed while doing it. A check that doesn't clean up damages somebody else's, so it presents as an unrelated breakage further down the file. It closes the panel now, and asserts it closed.

`window.__study` gains `openSection()` so the check can reach a lecture without walking the enrolment flow first; a test that has to enrol before it can assert anything is testing enrolment.

Full suite green locally — 45 checks, including the walk-mode set added in v133.

First PR to run against the cached browser from #92.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_