### PR TITLE
v135: the objective names something you can actually do

### DIFF
--- a/index.html
+++ b/index.html
@@ -3431,7 +3431,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v134";
+const BUILD = "pembroke-v135";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -11668,9 +11668,40 @@ function questInfo(){
      stands. */
   const J = window.__journey && window.__journey.get();
   const regd = J && J.registration.completedAt ? J.registration.registeredCourseIds : null;
-  const next = (regd && COURSES.find(c => regd.includes(c.id) && !done.includes(c.id)))
-            || COURSES.find(c => !done.includes(c.id));
-  if (!next) return { text:"Degree complete — Summa Cum Laude. The campus is yours, laureate. 🎓" };
+  /* AND IT MUST NAME SOMETHING YOU CAN ACTUALLY DO. Eleven of the
+     twelve courses are catalogue entries — outcomes, a textbook, a
+     code snippet — with no lectures behind them, and this line used
+     to send people to a hall to attend one of them. It is the single
+     permanently visible instruction in the product, so a dead end
+     here is the most expensive dead end there is: a visitor who
+     follows it and finds nothing has been told, by the campus
+     itself, that following instructions does not work.
+     `taught` is the whole difference. */
+  const open = c => !done.includes(c.id);
+  const taught = c => open(c) && !!STUDY[c.id];
+  const next = (regd && COURSES.find(c => regd.includes(c.id) && taught(c)))
+            || COURSES.find(taught)
+            || null;
+  if (!next){
+    /* Nothing teachable is left, which is a different thing from a
+       finished degree and must not be dressed as one. Two honest
+       endings: every lecture cleared, or the catalogue is ahead of
+       the lecture hall. Both point somewhere real. */
+    if (!COURSES.some(open))
+      return { text:"Degree complete — Summa Cum Laude. The campus is yours, laureate. 🎓" };
+    /* Read from the catalogue rather than naming a course: the first
+       draft of this said "MATH 201 is teaching now" in the branch that
+       fires only when NOTHING is teaching, which would have been the
+       same kind of lie in smaller type. */
+    /* NO `sector` on this one. The only thing that reads it fires a
+       "Class attended — you made it to lecture" toast when you walk
+       into the hall the objective names, and there is no lecture to
+       have attended here. The text still says where to go; the
+       congratulation would be the lie. */
+    return { text: COURSES.some(c => STUDY[c.id])
+               ? "Every lecture the Academy teaches is sealed — browse the catalogue, or find Prof. Merion by the Great Library"
+               : "Browse the catalogue — every course here is syllabus and text for now" };
+  }
   const S = SECTORS[next.sector];
   return { sector: next.sector, text:`Attend ${next.code} · ${next.title} — walk to ${S.hall}` };
 }
@@ -11737,6 +11768,9 @@ function refreshQuest(){
      from outside the module */
   window.__refreshQuest = () => refreshQuest();
 }
+/* the objective itself, so a check can read what it NAMES rather than
+   scraping the sentence off the screen and hoping the wording holds */
+window.__quest = () => questInfo();   /* test/debug hook */
 const mm = document.getElementById("minimap");
 function drawMinimap(){
   const ctx = mm.getContext("2d");
@@ -12187,7 +12221,13 @@ function courseCard(c){
         <span class="font-mono-d text-[9.5px] px-1.5 py-0.5 rounded border" style="color:${S.color};border-color:${S.soft}.4)">${mastered}/${total} lectures</span>
       </span>
       <span class="chev text-slate-400 text-xs">›</span>
-    </button>`; })() : ""}
+    </button>`; })() : `
+    <div class="mt-4 flex items-center gap-2.5 rounded-xl px-4 py-2.5 text-left"
+         style="background:rgba(148,163,184,.05);border:1px dashed rgba(148,163,184,.25)">
+      <span class="font-serif-d text-[15px] text-slate-500">§</span>
+      <span class="text-[11px] uppercase tracking-[.2em] text-slate-500">Syllabus only</span>
+      <span class="text-[11.5px] text-slate-500 italic">the outcomes and the text are set; the lectures are not written yet</span>
+    </div>`}
     <button class="pg-toggle w-full mt-4 flex items-center justify-between rounded-xl px-4 py-2.5 text-left transition hover:brightness-125"
             data-toggle="${c.id}" style="background:${S.soft}.08);border:1px solid ${S.soft}.25)">
       <span class="flex items-center gap-2.5">
@@ -15196,7 +15236,11 @@ function hallRecord(key){
           <span class="int-state ${st.cls}">${esc(st.label)}</span>
         </div>
         <div class="int-meta">${esc(c.level)} · ${c.credits} credits${
-          t ? ` · taught by <b>${esc(t.name)}</b>` : ""}</div>
+          t ? ` · taught by <b>${esc(t.name)}</b>` : ""}${
+          /* a hall that lists a course it cannot teach yet says so
+             here too — the panel is the thing somebody walked across
+             the campus to read */
+          STUDY[c.id] ? "" : `<br><i>Syllabus only — the lectures are not written yet.</i>`}</div>
       </div>`;
     }).join("")}
     <div class="int-sec">Faculty · ${staff.length} in residence</div>
@@ -15861,7 +15905,9 @@ function renderJourney(){
         return `<div class="jtt">
           <span class="jtt-code" style="color:${S.color};border-color:${S.soft}.4)">${c.code}</span>
           <span class="jtt-body"><span class="jtt-t">${c.title}</span>
-          <span class="jtt-where">meets in <button class="jlink" data-hall="${c.sector}">${S.hall} →</button>${STUDY[id] ? ` · <button class="jlink" data-sty="${id}">course of study</button>` : ""}</span></span>
+          <span class="jtt-where">meets in <button class="jlink" data-hall="${c.sector}">${S.hall} →</button>${
+            STUDY[id] ? ` · <button class="jlink" data-sty="${id}">course of study</button>`
+                      : ` · <span class="text-slate-500 italic">syllabus only for now</span>`}</span></span>
         </div>`; }).join("")}` : ""}
     ${firstNow && ctas[firstNow[0]] ? `<button class="jcta" id="jgo">${ctas[firstNow[0]][0]}</button>` : ""}
     <div class="mt-2 flex flex-wrap gap-x-4">

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v134";
+const VERSION = "pembroke-v135";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -201,6 +201,52 @@ try {
   step("all twelve courses render", shelf.courses === 12, shelf.courses + " cards");
   step("registrar ledger reports", /\d/.test(shelf.total), JSON.stringify(shelf.total));
 
+  /* THE ONE PERMANENTLY VISIBLE INSTRUCTION MUST NAME SOMETHING YOU
+     CAN DO. Eleven of the twelve courses are catalogue entries with no
+     lectures behind them, and the objective used to pick the first
+     uncompleted course with no check for that — so a fully enrolled
+     student was told to "Attend MATH 101 · College Algebra", walked to
+     the Great Library, and found nothing there. A dead end here is the
+     most expensive one in the product: it teaches the visitor that
+     following the campus's instructions does not work.
+
+     Every stage, because the objective renders at every stage and the
+     bug was present at all of them. Set directly rather than clicked
+     through — six stages of clicking would be testing the journey. */
+  const quest = await page.evaluate(() => {
+    const J = window.__journey, out = [];
+    const order = ["visitor","applicant","accepted","advised","declared","enrolled"];
+    for (const stage of order){
+      J.reset();
+      J.patch(j => {
+        const at = Date.now(), upto = order.indexOf(stage);
+        if (upto >= 1) j.admissions.applicationSubmittedAt = at;
+        if (upto >= 2) j.admissions.acceptedAt = at;
+        if (upto >= 3) j.advising.completedAt = at;
+        if (upto >= 4){ j.academics.declaredMajorId = "lib"; j.academics.declaredAt = at; }
+        if (upto >= 5){ j.registration.registeredCourseIds = ["MATH101","MATH120","MATH201"];
+                        j.registration.completedAt = at; }
+      });
+      const q = window.__quest();
+      const m = /\b([A-Z]{2,4})\s?(\d{3})\b/.exec(q.text || "");
+      const id = m ? m[1] + m[2] : null;
+      out.push({ stage, id, text: (q.text || "").slice(0, 60), sector: q.sector || null,
+                 teachable: !id || !!window.__study.STUDY[id] });
+    }
+    J.reset();
+    return out;
+  });
+  const dead = quest.filter(r => !r.teachable);
+  step("the objective always names something that can be done",
+       dead.length === 0,
+       dead.length ? dead.map(r => `${r.stage} → ${r.id} has no lessons`).join(" · ")
+                   : quest.map(r => r.stage + ":" + (r.id || "no course")).join(" "));
+  /* q.sector fires a "you made it to lecture" toast on entering that
+     hall — it must not be set for an objective with no lecture in it */
+  const congrats = quest.filter(r => r.sector && !(r.id && r.teachable));
+  step("no lecture is congratulated where none is taught", congrats.length === 0,
+       congrats.map(r => r.stage + " → sector " + r.sector).join(" · ") || "every sector earns its toast");
+
   /* An unanswered knowledge check is not a wrong one. Submitting with
      nothing selected used to mark every question wrong, reveal every
      answer permanently, and write a miss per question into the study


### PR DESCRIPTION
Closes #68.

`STUDY` holds one key. Eleven of the twelve courses are catalogue entries — outcomes, a textbook, a code snippet — with no lectures behind them, and `questInfo()` picked the first uncompleted course with no check for that. A fully enrolled student registered for MATH 101, 120 and 201 was told:

> `Attend MATH 101 · College Algebra — walk to The Pembroke Great Library`

They walk there and there is nothing to attend. This is the **single permanently visible instruction in the product**, so a dead end here is the most expensive one available: it teaches the visitor that following the campus's own instructions does not work.

Reproduced at every stage before fixing — twelve failures, visitor through enrolled — and the text matched the report exactly.

## Teachability is the whole difference

The objective prefers a registered course that has lessons, falls back to any course that has lessons, and only then to something that is not a course at all. Both non-course endings are honest and distinct: a finished degree, or a catalogue that has run ahead of the lecture hall.

## The part that would have been a new bug

`questInfo()` returns a `sector`, and the only thing that reads it fires a **"Class attended — you made it to lecture"** toast when you walk into the hall the objective names.

My first draft returned `sector: "lib"` on the fallback, for wayfinding. That would have congratulated a visitor for attending a lecture that does not exist. The fallback carries no sector now — the text still says where to go, the congratulation was the lie — and the suite asserts it separately.

Same class of thing, caught in the same pass: the fallback message first read *"MATH 201 is teaching now"* in the branch that fires **only when nothing is teaching**. It reads from the catalogue instead.

## And the eleven say so

Silently omitting the study link left the gap invisible and the promise intact. Three places now state it:

| where | what it says |
|---|---|
| course card | dashed panel — *"Syllabus only — the outcomes and the text are set; the lectures are not written yet"* |
| timetable row | *"· syllabus only for now"* beside the hall link |
| hall panel (v132) | *"Syllabus only — the lectures are not written yet."* under the course |

## Verification

In `tools/smoke.mjs`, across all six journey stages the issue lists, set directly rather than clicked through — six stages of clicking would be testing the journey, not the objective:

```
  ok   the objective always names something that can be done
       — visitor:MATH201 applicant:MATH201 accepted:MATH201 advised:MATH201 declared:MATH201 enrolled:MATH201
  ok   no lecture is congratulated where none is taught  — every sector earns its toast
```

Verified the only way worth verifying — with the teachability test removed, both fail at **every** stage:

```
 FAIL  enrolled: the objective is reachable
       — "Attend MATH 101 · College Algebra — walk to The Pembroke Great Library" · names MATH101 (NO LESSONS)
```

`window.__quest` is added so the check reads what the objective *names* rather than scraping the sentence off the screen and hoping the wording holds.

Full suite green locally — 52 checks. The quest block resets the Journey afterwards and the walk-mode and knowledge-check sets that follow it are unaffected.

Content for the remaining eleven courses is tracked separately (#76).

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_