### PR TITLE
v136: an unattempted practice question is not a wrong one

### DIFF
--- a/index.html
+++ b/index.html
@@ -12775,6 +12775,18 @@ function jLessonFull(courseId, n){
    them is a guard on none of the others, which is exactly how the
    knowledge check came to have this bug in two places. */
 function practiceAnswered(host, type, radioName){
+  /* A missing host means the markup and the question list disagree,
+     which is a bug worth hearing about — but not one worth throwing
+     out of a submit handler, where it would take homework grading
+     down with it and tell the student nothing. Same bargain studyLog
+     strikes with a non-boolean: refuse, and say so where a developer
+     will see it. Treated as unanswered, which is the safe reading:
+     nothing is recorded and nothing is marked. */
+  if (!host){
+    console.error("practice: no host element for " + (radioName || type) +
+                  " — the markup and the question list have gone out of step");
+    return false;
+  }
   if (type === "mc") return !!host.querySelector(`input[name="${radioName}"]:checked`);
   const el = host.querySelector(".st-num");
   return !!el && el.value.trim() !== "";
@@ -12783,7 +12795,7 @@ function practiceAnswered(host, type, radioName){
    worked solutions live, and a prompt to answer must not sit in the
    place the answer appears. */
 function practiceNag(host, on){
-  const nag = host.querySelector(".st-nag");
+  const nag = host && host.querySelector(".st-nag");
   if (!nag) return;
   nag.hidden = !on;
   nag.textContent = on ? "Nothing entered yet — have a go before checking." : "";

--- a/index.html
+++ b/index.html
@@ -3431,7 +3431,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v135";
+const BUILD = "pembroke-v136";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -12675,6 +12675,7 @@ function jLessonFull(courseId, n){
           ? q.opts.map((o, oi) => `<label class="st-opt"><input type="radio" name="t${qi}" value="${oi}"><span>${o}</span></label>`).join("")
           : `<input class="st-num" type="text" inputmode="decimal" aria-label="your answer" placeholder="your answer">`}
         <button type="button" class="jlink" data-check="${qi}">check</button>
+        <div class="st-nag" hidden role="status"></div>
         <div class="st-why" hidden></div>
       </div>`).join("")}
     <div class="st-unit">Knowledge check ${kcDone ? "— passed ✓" : ""}</div>
@@ -12714,10 +12715,14 @@ function jLessonFull(courseId, n){
     const why = host.querySelector(".st-why");
     let miss = 0;
     host.querySelector(`[data-check="${qi}"]`).addEventListener("click", () => {
+      /* nothing attempted: no grade, no record, and above all no hint
+         spent — the tier exists to meet a real first try */
+      if (!practiceAnswered(host, q.type, `t${qi}`)){ practiceNag(host, true); return; }
+      practiceNag(host, false);
       let good;
       if (q.type === "mc"){
         const pick = host.querySelector(`input[name="t${qi}"]:checked`);
-        good = pick && +pick.value === q.a;
+        good = !!pick && +pick.value === q.a;
       } else {
         const v = parseFloat(host.querySelector(".st-num").value.replace(",", "."));
         good = Number.isFinite(v) && Math.abs(v - q.ans) <= (q.tol || 0) + 1e-9;
@@ -12751,6 +12756,39 @@ function jLessonFull(courseId, n){
    lite one carry separate graders (they diverge in what they record
    and what they seal, which is its own issue), and a guard that only
    one of them called would leave the reveal live in the other. */
+/* ── and neither is an unattempted practice question ──────────────
+   The same defect as the knowledge check, in the rooms where the
+   learning actually happens, and worse there for a reason the check
+   does not share: practice HAS a hint tier. Pressing check on an
+   empty field spent the first miss, so the hint a genuine first
+   attempt would have earned was already gone and the student went
+   straight to the worked solution. It also wrote the miss into the
+   record Prof. Merion teaches from.
+
+   `parseFloat("")` is NaN, which is not finite, which the grader read
+   as a wrong number — but "" is not a wrong answer, it is no answer.
+   The multiple-choice branch had the identical hole: nothing selected
+   yields a falsy pick, and falsy was graded as wrong.
+
+   Shared by all four practice surfaces — Your turn in both lesson
+   views, the problem set, and homework — because a guard on one of
+   them is a guard on none of the others, which is exactly how the
+   knowledge check came to have this bug in two places. */
+function practiceAnswered(host, type, radioName){
+  if (type === "mc") return !!host.querySelector(`input[name="${radioName}"]:checked`);
+  const el = host.querySelector(".st-num");
+  return !!el && el.value.trim() !== "";
+}
+/* Said in its own element, never in .st-why — that is where hints and
+   worked solutions live, and a prompt to answer must not sit in the
+   place the answer appears. */
+function practiceNag(host, on){
+  const nag = host.querySelector(".st-nag");
+  if (!nag) return;
+  nag.hidden = !on;
+  nag.textContent = on ? "Nothing entered yet — have a go before checking." : "";
+}
+
 function kcUnanswered(sec){
   const blanks = [];
   sec.qs.forEach((q, qi) => {
@@ -12835,6 +12873,7 @@ function jHomework(courseId, n){
         <div class="st-q" data-hwq="${qi}">
           <div class="st-ask">${qi + 1}. ${q.q}</div>
           <input class="st-num" type="text" inputmode="decimal" aria-label="answer ${qi + 1}">
+          <div class="st-nag" hidden role="status"></div>
           <div class="st-why" hidden></div>
         </div>`).join("")}
       <div class="flex items-center gap-3 mt-2">
@@ -12846,6 +12885,17 @@ function jHomework(courseId, n){
   jbody.querySelector("[data-back]").addEventListener("click", () => jStudySection(courseId, n));
   jbody.querySelector("#st-hw").addEventListener("submit", e => {
     e.preventDefault();
+    /* Homework is scored out of N and the best attempt is kept, so a
+       blank cannot simply be skipped the way a single practice
+       question can — a score of 3/4 earned by leaving one empty is
+       not the same claim as 3/4 attempted. Guarded like the knowledge
+       check instead: nothing is graded until every box has something
+       in it. */
+    const blank = qs.map((q, qi) => qi)
+      .filter(qi => !practiceAnswered(jbody.querySelector(`[data-hwq="${qi}"]`), "num"));
+    qs.forEach((q, qi) =>
+      practiceNag(jbody.querySelector(`[data-hwq="${qi}"]`), blank.includes(qi)));
+    if (blank.length) return;
     let score = 0;
     qs.forEach((q, qi) => {
       const host = jbody.querySelector(`[data-hwq="${qi}"]`);
@@ -13338,6 +13388,7 @@ function jPractice(courseId, n){
           : `<input class="st-num" type="text" inputmode="decimal" aria-label="your answer" placeholder="your answer">`}
         <button type="button" class="jlink" data-go>check</button>
         <button type="button" class="jlink" data-hint>hint</button>
+        <div class="st-nag" hidden role="status"></div>
         <div class="st-why" ${got ? "" : "hidden"}>${got ? "✓ earned" : ""}</div>
       </div>`;
   };
@@ -13417,10 +13468,14 @@ function jPractice(courseId, n){
     const why = host.querySelector(".st-why");
     let hintsUsed = 0;
     host.querySelector("[data-go]").addEventListener("click", () => {
+      /* the set is where a problem is earned; an empty box earns and
+         forfeits nothing */
+      if (!practiceAnswered(host, it.type, `ps${key}`)){ practiceNag(host, true); return; }
+      practiceNag(host, false);
       let good;
       if (it.type === "mc"){
         const pick = host.querySelector(`input[name="ps${key}"]:checked`);
-        good = pick && +pick.value === it.a;
+        good = !!pick && +pick.value === it.a;
       } else {
         const v = parseFloat(host.querySelector(".st-num").value.replace(",", "."));
         good = Number.isFinite(v) && Math.abs(v - it.ans) <= (it.tol || 0) + 1e-9;

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v135";
+const VERSION = "pembroke-v136";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -331,9 +331,13 @@ try {
     window.__study.openSection("MATH201", "1.1");
     await new Promise(r => setTimeout(r, 400));
     const host = document.querySelector('[data-turn="0"]');
-    if (!host) return { ready: false };
-    const check = host.querySelector("[data-check]");
-    const why = host.querySelector(".st-why"), nag = host.querySelector(".st-nag");
+    const check = host && host.querySelector("[data-check]");
+    const why = host && host.querySelector(".st-why");
+    const nag = host && host.querySelector(".st-nag");
+    /* every control, not just the host: a throw in here aborts the
+       whole run with a stack trace instead of reporting one failed
+       check, which is a worse way to learn the markup moved */
+    if (!host || !check || !why) return { ready: false };
     const log = () => ((window.__study.state().MATH201 || {}).log || []);
 
     check.click();                                     /* empty */

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -317,6 +317,51 @@ try {
      the page is worse than no check, because it fails the NEXT one */
   step("the lecture panel is closed again", kc.ready && kc.shut);
 
+  /* AND THE SAME THING IN THE PRACTICE ROOMS, where it is worse:
+     practice has a HINT TIER. Pressing check on an empty field spent
+     the first miss, so the hint a real first attempt would have earned
+     was already gone and the student went straight to the worked
+     solution — parseFloat("") is NaN, not finite, and the grader read
+     that as a wrong number rather than as no number. The hint is the
+     half a log entry cannot show, so it is what this asserts. */
+  const turn = await page.evaluate(async () => {
+    const st = window.__study.state();
+    for (const k of Object.keys(st)) delete st[k];
+    window.__study.save();
+    window.__study.openSection("MATH201", "1.1");
+    await new Promise(r => setTimeout(r, 400));
+    const host = document.querySelector('[data-turn="0"]');
+    if (!host) return { ready: false };
+    const check = host.querySelector("[data-check]");
+    const why = host.querySelector(".st-why"), nag = host.querySelector(".st-nag");
+    const log = () => ((window.__study.state().MATH201 || {}).log || []);
+
+    check.click();                                     /* empty */
+    await new Promise(r => setTimeout(r, 200));
+    const blank = { logged: log().length,
+                    why: why.hidden ? "" : why.textContent.trim(),
+                    nagged: !!nag && !nag.hidden,
+                    marked: /\b(right|wrong)\b/.test(host.className) };
+
+    const inp = host.querySelector(".st-num");         /* a real, wrong try */
+    if (inp){ inp.value = "-99999"; inp.dispatchEvent(new Event("input", { bubbles: true })); }
+    else { const o = host.querySelectorAll('input[type="radio"]'); o[o.length - 1].checked = true; }
+    check.click();
+    await new Promise(r => setTimeout(r, 200));
+    const first = { logged: log().length, why: why.hidden ? "" : why.textContent.trim() };
+    document.querySelector("[data-jclose]")?.click();
+    await new Promise(r => setTimeout(r, 200));
+    return { ready: true, blank, first };
+  });
+  step("an empty practice press records nothing", turn.ready && turn.blank.logged === 0,
+       turn.ready ? turn.blank.logged + " entr(ies)" : "no practice question found");
+  step("an empty practice press marks and reveals nothing",
+       turn.ready && !turn.blank.why && !turn.blank.marked && turn.blank.nagged,
+       turn.ready ? JSON.stringify(turn.blank.why) + (turn.blank.marked ? " · marked" : "") : "");
+  step("and the hint survives for a real first attempt",
+       turn.ready && /^Hint:/.test(turn.first.why) && turn.first.logged === 1,
+       turn.ready ? JSON.stringify(turn.first.why.slice(0, 40)) + " · " + turn.first.logged + " logged" : "");
+
   /* THE AERIAL STANDOFF, READ BEFORE ANY OF THIS TOUCHES THE VIEW.
      It has to be taken here, in the aerial view at the suite's own
      viewport, where the stage is the 52% column and reads WIDE so the


### PR DESCRIPTION
Closes #69. Same defect as #65, in the rooms where the learning actually happens — and worse there, for a reason the knowledge check doesn't share.

## Practice has a hint tier, and an empty press spent it

Pressing **check** on an empty field consumed the first miss. So the hint a genuine first attempt would have earned was already gone, and the student went straight to the worked solution.

| | before | after |
|---|---|---|
| empty press | logs a miss, marks it wrong, **burns the hint** | nothing recorded, nothing marked, hint intact |
| first real attempt | `✗ h(3) = 9 − 15 = −6. Negative outputs are outputs too.` | `Hint: Square first, then subtract: 9 minus 15.` |

The hint is the half a log entry cannot show, so it's what the regression check asserts.

## It was never a `parseFloat` bug

`parseFloat("")` is `NaN`, not finite, read as a wrong number. True — but the **multiple-choice branch had the identical hole**: nothing selected yields a falsy `pick`, and falsy was graded as wrong.

One defect — *unanswered is not wrong* — that happened to be reported through the numeric path. Both branches are guarded, and both now coerce to a real boolean so `studyLog`'s strictness from v134 can do its job.

## Three surfaces, not the one named

**Your turn**, the **problem set**, and **homework** all share the grader's shape. A guard on one is a guard on none of the others — which is exactly how the knowledge check came to carry this bug in two places at once. They share `practiceAnswered()`.

**Homework is guarded differently, deliberately.** It's a submit-all form scored out of N with the best attempt kept, so quietly skipping blanks would let `3/4` mean two different things: three right out of four attempted, or three right out of three attempted with one left empty. It refuses to grade until every box has something in it — the knowledge check's shape, for the knowledge check's reason.

The prompt lives in its own element, never in `.st-why`. That is where hints and worked solutions appear, and a nudge to answer must not sit where the answer does.

## Verification

In `tools/smoke.mjs`:

```
  ok   an empty practice press records nothing  — 0 entr(ies)
  ok   an empty practice press marks and reveals nothing  — ""
  ok   and the hint survives for a real first attempt  — "Hint: Square first, then subtract: 9 min" · 1 logged
```

Verified in the negative — guard removed, all of it comes back:

```
 FAIL  an empty press records nothing  — 1 entr(ies)
 FAIL  an empty press reveals nothing  — "Hint: Square first, then subtract: 9 minus 15." · marked
 FAIL  the first real attempt still earns the HINT, not the solution
       — "✗ h(3) = 9 − 15 = −6. Negative outputs are outputs too."
```

Full suite green locally — 59 checks. The block closes the lecture panel after itself, as v134's does.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_