### PR TITLE
v137: restore the lecture check that #94 merged without

### DIFF
--- a/index.html
+++ b/index.html
@@ -3123,12 +3123,20 @@ function loadStudy(){
 let study = loadStudy();
 function saveStudy(){ try{ localStorage.setItem(LS_STUDY, JSON.stringify(study)); }catch(_){} }
 function studySections(id){ return (STUDY[id]?.units || []).flatMap(u => u.sections); }
+/* THE HONEST PREDICATE FOR "THIS COURSE CAN BE STUDIED", and the only
+   one anything should use. A STUDY key is not the same claim: content
+   arrives course by course, so an entry can exist with its units still
+   empty, and every place that tested `STUDY[id]` for truthiness would
+   have called that teachable — putting the dead end straight back
+   without a single test noticing, because the tests asked the same
+   wrong question. Sections are what a student actually opens. */
+function hasLectures(id){ return studySections(id).length > 0; }
 function studyProgress(id){
   const all = studySections(id);
   const st = study[id] || {};
   return { total: all.length, mastered: all.filter(s => st[s.n] === 2).length };
 }
-window.__study = { STUDY, progress: studyProgress, state: () => study,
+window.__study = { STUDY, progress: studyProgress, state: () => study, hasLectures,
                    psetOf, psetState, psetGradedKeys, save: saveStudy,
                    /* open a lecture directly: the panel is otherwise
                       four clicks deep behind enrolment, and a check
@@ -3431,7 +3439,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v136";
+const BUILD = "pembroke-v137";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -11678,10 +11686,23 @@ function questInfo(){
      itself, that following instructions does not work.
      `taught` is the whole difference. */
   const open = c => !done.includes(c.id);
-  const taught = c => open(c) && !!STUDY[c.id];
-  const next = (regd && COURSES.find(c => regd.includes(c.id) && taught(c)))
-            || COURSES.find(taught)
-            || null;
+  const taught = c => open(c) && hasLectures(c.id);
+  const mine = regd && COURSES.find(c => regd.includes(c.id) && taught(c));
+  const anywhere = COURSES.find(taught) || null;
+  /* An ENROLLED student whose own schedule has nothing teachable on it
+     is a different case from a visitor with no schedule at all, and
+     saying "Attend MATH 201" to an engineering major is wrong twice
+     over: it is not their course, and they could not have registered
+     for it. The syllabus genuinely is open to anyone — Prof. Merion's
+     own brief says so — so the invitation is real. It is an
+     invitation, not an instruction, and it carries no sector: walking
+     into the Great Library for somebody else's lecture is not a class
+     attended. */
+  if (regd && !mine && anywhere)
+    return { id: anywhere.id,
+             text: `Your registered courses are syllabus only for now — ${anywhere.code} in ` +
+                   `${SECTORS[anywhere.sector].hall} is open to anyone who wants to sit it` };
+  const next = mine || anywhere;
   if (!next){
     /* Nothing teachable is left, which is a different thing from a
        finished degree and must not be dressed as one. Two honest
@@ -11698,12 +11719,18 @@ function questInfo(){
        into the hall the objective names, and there is no lecture to
        have attended here. The text still says where to go; the
        congratulation would be the lie. */
-    return { text: COURSES.some(c => STUDY[c.id])
+    return { text: COURSES.some(c => hasLectures(c.id))
                ? "Every lecture the Academy teaches is sealed — browse the catalogue, or find Prof. Merion by the Great Library"
                : "Browse the catalogue — every course here is syllabus and text for now" };
   }
   const S = SECTORS[next.sector];
-  return { sector: next.sector, text:`Attend ${next.code} · ${next.title} — walk to ${S.hall}` };
+  /* `id` so a check can assert on the course itself. The test used to
+     pull a code out of the sentence with a regex, which is a test of
+     the wording — and a reviewer's probe reading the same shape got
+     nine false passes out of it, comparing undefined to undefined and
+     ticking green. Data, not prose. */
+  return { id: next.id, sector: next.sector,
+           text:`Attend ${next.code} · ${next.title} — walk to ${S.hall}` };
 }
 function refreshQuest(){
   document.getElementById("quest-text").textContent = questInfo().text;
@@ -12210,7 +12237,7 @@ function courseCard(c){
       </div>
     </div>
 
-    ${STUDY[c.id] ? (() => {
+    ${hasLectures(c.id) ? (() => {
       const { total, mastered } = studyProgress(c.id);
       return `
     <button class="pg-toggle w-full mt-4 flex items-center justify-between rounded-xl px-4 py-2.5 text-left transition hover:brightness-125"
@@ -15268,7 +15295,7 @@ function setPlate(key){
 function courseStanding(c, reg){
   if (done.includes(c.id)) return { cls: "sealed", label: "sealed" };
   if (reg.includes(c.id))  return { cls: "open",   label: "registered" };
-  const p = STUDY[c.id] ? studyProgress(c.id) : null;
+  const p = hasLectures(c.id) ? studyProgress(c.id) : null;
   if (p && p.mastered)     return { cls: "open",   label: p.mastered + "/" + p.total + " mastered" };
   return { cls: "wait", label: c.prereqs.length
     ? "needs " + c.prereqs.map(id => byId[id]?.code || id).join(" · ")
@@ -15307,7 +15334,7 @@ function hallRecord(key){
           /* a hall that lists a course it cannot teach yet says so
              here too — the panel is the thing somebody walked across
              the campus to read */
-          STUDY[c.id] ? "" : `<br><i>Syllabus only — the lectures are not written yet.</i>`}</div>
+          hasLectures(c.id) ? "" : `<br><i>Syllabus only — the lectures are not written yet.</i>`}</div>
       </div>`;
     }).join("")}
     <div class="int-sec">Faculty · ${staff.length} in residence</div>
@@ -15397,7 +15424,7 @@ function openInterior(key){
   /* the panel is an access path into the course of study — the
      efficient path stays on the course card, this one is for the
      student who walked here */
-  const studyHere = COURSES.find(c => c.sector === key && STUDY[c.id]);
+  const studyHere = COURSES.find(c => c.sector === key && hasLectures(c.id));
   const sb = document.getElementById("int-study");
   sb.hidden = !studyHere;
   if (studyHere) sb.onclick = () => { closeInterior(); jStudy(studyHere.id); };
@@ -15973,7 +16000,7 @@ function renderJourney(){
           <span class="jtt-code" style="color:${S.color};border-color:${S.soft}.4)">${c.code}</span>
           <span class="jtt-body"><span class="jtt-t">${c.title}</span>
           <span class="jtt-where">meets in <button class="jlink" data-hall="${c.sector}">${S.hall} →</button>${
-            STUDY[id] ? ` · <button class="jlink" data-sty="${id}">course of study</button>`
+            hasLectures(id) ? ` · <button class="jlink" data-sty="${id}">course of study</button>`
                       : ` · <span class="text-slate-500 italic">syllabus only for now</span>`}</span></span>
         </div>`; }).join("")}` : ""}
     ${firstNow && ctas[firstNow[0]] ? `<button class="jcta" id="jgo">${ctas[firstNow[0]][0]}</button>` : ""}
@@ -16098,7 +16125,7 @@ if (Journey.get().onboarding.campusVisit.status === "active"){ orientOn = true; 
    FRAME actually cost that is not a guess reconstructed by walking
    the scene graph. */
 window.__app = { selectSector, openInterior, camera, controls, world, THREE,
-                 renderer };   /* test/debug hooks */
+                 renderer, COURSES };   /* test/debug hooks */
 aerialHome();          /* now that #stage has a real size, frame for it */
 applyMode();
 renderChips();

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v136";
+const VERSION = "pembroke-v137";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -216,22 +216,35 @@ try {
   const quest = await page.evaluate(() => {
     const J = window.__journey, out = [];
     const order = ["visitor","applicant","accepted","advised","declared","enrolled"];
+    /* every declarable major, not just the mathematics one: an enrolled
+       engineering student's schedule holds no course with lectures, and
+       naming the Great Library's calculus as their objective is wrong
+       twice — not their course, and not one they could have registered
+       for. Only the enrolled rows can show it, which is why the major
+       is varied here and not at every stage. */
     for (const stage of order){
-      J.reset();
-      J.patch(j => {
-        const at = Date.now(), upto = order.indexOf(stage);
-        if (upto >= 1) j.admissions.applicationSubmittedAt = at;
-        if (upto >= 2) j.admissions.acceptedAt = at;
-        if (upto >= 3) j.advising.completedAt = at;
-        if (upto >= 4){ j.academics.declaredMajorId = "lib"; j.academics.declaredAt = at; }
-        if (upto >= 5){ j.registration.registeredCourseIds = ["MATH101","MATH120","MATH201"];
-                        j.registration.completedAt = at; }
-      });
-      const q = window.__quest();
-      const m = /\b([A-Z]{2,4})\s?(\d{3})\b/.exec(q.text || "");
-      const id = m ? m[1] + m[2] : null;
-      out.push({ stage, id, text: (q.text || "").slice(0, 60), sector: q.sector || null,
-                 teachable: !id || !!window.__study.STUDY[id] });
+      for (const major of ["lib", "eng", "sci", "adm"]){
+        if (stage !== "enrolled" && major !== "lib") continue;
+        J.reset();
+        J.patch(j => {
+          const at = Date.now(), upto = order.indexOf(stage);
+          if (upto >= 1) j.admissions.applicationSubmittedAt = at;
+          if (upto >= 2) j.admissions.acceptedAt = at;
+          if (upto >= 3) j.advising.completedAt = at;
+          if (upto >= 4){ j.academics.declaredMajorId = major; j.academics.declaredAt = at; }
+          if (upto >= 5){
+            j.registration.registeredCourseIds =
+              window.__app.COURSES.filter(c => c.sector === major).map(c => c.id);
+            j.registration.completedAt = at;
+          }
+        });
+        const q = window.__quest();
+        out.push({ stage, major, id: q.id || null, sector: q.sector || null,
+                   text: (q.text || "").slice(0, 64),
+                   /* the honest predicate the product itself uses — a
+                      STUDY key is not the same claim as a lecture */
+                   teachable: !q.id || window.__study.hasLectures(q.id) });
+      }
     }
     J.reset();
     return out;
@@ -239,13 +252,39 @@ try {
   const dead = quest.filter(r => !r.teachable);
   step("the objective always names something that can be done",
        dead.length === 0,
-       dead.length ? dead.map(r => `${r.stage} → ${r.id} has no lessons`).join(" · ")
-                   : quest.map(r => r.stage + ":" + (r.id || "no course")).join(" "));
+       dead.length ? dead.map(r => `${r.stage}/${r.major} → ${r.id} has no lectures`).join(" · ")
+                   : quest.map(r => r.stage + "/" + r.major + ":" + (r.id || "—")).join(" "));
   /* q.sector fires a "you made it to lecture" toast on entering that
-     hall — it must not be set for an objective with no lecture in it */
+     hall. It may only be set when the objective names a course that is
+     both teachable AND the student's own — an enrolled engineer sent
+     to the calculus lecture has not attended their class. */
   const congrats = quest.filter(r => r.sector && !(r.id && r.teachable));
   step("no lecture is congratulated where none is taught", congrats.length === 0,
-       congrats.map(r => r.stage + " → sector " + r.sector).join(" · ") || "every sector earns its toast");
+       congrats.map(r => r.stage + "/" + r.major + " → sector " + r.sector).join(" · ")
+         || "every sector earns its toast");
+
+  /* AND THE STUB, which is the shape this bug comes back in. Content
+     lands course by course, so a course gets its STUDY entry before
+     its lectures are written — and every test of `STUDY[id]` for
+     truthiness calls that teachable. Caught in review: the fix passed
+     its own test while a one-line stub put the dead end straight back.
+     Injected here because the product cannot reach the state on its
+     own yet, and the day it can is the day this must already hold. */
+  const stub = await page.evaluate(() => {
+    window.__study.STUDY.MATH101 = { units: [] };          /* keyed, no lectures */
+    window.__journey.reset();
+    const q = window.__quest();
+    const r = { keyed: !!window.__study.STUDY.MATH101,
+                lectures: window.__study.hasLectures("MATH101"),
+                id: q.id || null, sector: q.sector || null };
+    delete window.__study.STUDY.MATH101;
+    return r;
+  });
+  step("a course keyed with no lectures is not called teachable",
+       stub.keyed && !stub.lectures, `keyed ${stub.keyed} · hasLectures ${stub.lectures}`);
+  step("and the objective will not send anybody to one",
+       stub.id !== "MATH101" && !(stub.sector && stub.id === "MATH101"),
+       "names " + stub.id + " · sector " + stub.sector);
 
   /* An unanswered knowledge check is not a wrong one. Submitting with
      nothing selected used to mark every question wrong, reveal every


### PR DESCRIPTION
Not a new fix. This restores work that was reviewed, committed, and then left behind — main has been missing the substance of #68 since 01:25 last night.

## What happened

PR #94 merged as a **merge commit of its first commit**, `45cb5d4`, at 01:25. The follow-up that answered the review on it — `4a9e5e0`, *"A STUDY key is not a lecture"* — was authored at 01:08 but reached the remote after the merge had already taken that head. The PR closed around a tip that no longer represented the branch, and nothing pointed it out.

I found it by accident, reading `questInfo()` for an unrelated reason and noticing it didn't match what I'd written in #94's description.

## What is missing from main

```js
const taught = c => open(c) && !!STUDY[c.id];   // main, today
```

That tests for a **STUDY key**, not for lessons. Content lands course by course, so a course gets its entry before its lectures are written — and all seven sites that tested the key for truthiness call that teachable. #68's dead end reopens the day the first stub lands. `hasLectures(id)` — `studySections(id).length > 0` — is the honest question, and does not exist in main at all.

Also missing: the enrolled off-track major gets an invitation rather than an order to attend somebody else's calculus, and `questInfo()` returns the course id so checks read data instead of parsing prose.

## Why CI stayed green through five releases

The check that fails against a stub **travelled in the orphaned commit**. Main kept the version of the suite that asks the same wrong question the code does. Green for exactly the reason the bug was there.

## Verification

Full suite green locally — 57 checks, including the four restored ones:

```
  ok   the objective always names something that can be done
       — visitor/lib:MATH201 … enrolled/eng:MATH201 enrolled/sci:MATH201 enrolled/adm:MATH201
  ok   no lecture is congratulated where none is taught  — every sector earns its toast
  ok   a course keyed with no lectures is not called teachable  — keyed true · hasLectures false
  ok   and the objective will not send anybody to one  — names MATH201 · sector lib
```

Verified in the negative — `taught` put back to `!!STUDY[c.id]`, exactly as main has it:

```
 FAIL  and the objective will not send anybody to one  — names MATH101 · sector lib
       "Attend MATH 101 · College Algebra — walk to The Pembroke Great Library"
```

Dead end and false congratulation both, which is the defect sitting on main right now.

## Scope

Cherry-picked **unchanged** from `4a9e5e0` so the diff is the reviewed work and nothing else; only `BUILD` and the worker `VERSION` differ. `ASSETS_V` untouched — no asset changed.

I also swept all eleven remote branch tips against main for the same failure. This is the only one. Two other flags proved false: a CREDITS line my grep read as a command-line option, and a change a later merged commit deliberately deleted.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_