### PR TITLE
v138: the nameplates stay legible on a phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -753,6 +753,18 @@ body.diagnosing #campus-wing-intro{opacity:0;pointer-events:none;}
 body.day .hall-tag{background:linear-gradient(180deg, rgba(24,30,44,.86), rgba(24,30,44,.7));}
 .stu-tag{font-size:9px;letter-spacing:.08em;color:#f1f5f9;text-shadow:0 1px 3px rgba(0,0,0,.9);white-space:nowrap;}
 .walkmode .hall-tag .t2,.walkmode .hall-tag .t3{display:none;}
+/* Same collapse, for the same reason, one storey up: a portrait screen
+   makes standBack() pull the camera 1.5x out to fit the campus at all,
+   and every plate lands in a band a phone's width across. Three lines
+   apiece is three times the area to collide with — and the track line
+   sets at 7.5px, which is not type anybody reads at that scale. The
+   name and the sector flag survive; they are what the plate is for. */
+.plates-lean .hall-tag .t2,.plates-lean .hall-tag .t3{display:none;}
+/* Stood down by the declutter pass: another plate got these pixels
+   first. Not display:none — the pass re-measures every plate on the
+   next settle, and a plate with no box can never win its place back. */
+.hall-tag,.stu-tag{transition:opacity .22s ease;}
+.hall-tag.crowded-out,.stu-tag.crowded-out{opacity:0;}
 
 /* ── the hall panel ────────────────────────────────────────────── */
 #interior{
@@ -943,6 +955,30 @@ body.panel-open #toasts{bottom:5.5rem;}
   #scene{--zoom:.32;}
   #stage{padding-top:8.5rem;}
 }
+
+/* The bottom of the campus window holds three separately-anchored
+   boxes — the quest chip, the sector legend, the control hints — each
+   placed against a corner and none of them aware of the others. On a
+   laptop the width keeps them apart. On a phone it does not: measured
+   at 393px, "Administration · AI Robotics & Flight" printed straight
+   through "DRAG TO ORBIT · SCROLL TO ZOOM", and the objective chip sat
+   on the legend's first row.
+   Below 640px they stop being corners and become a stack up the left
+   edge: hints at the floor, legend above it, chip above that.
+   The offsets are MEASURED, and the first set was not. Estimating the
+   hints at "one or two 10px rows" put the legend 15px into a block
+   that renders 49px tall on a pointer that has hover — which is every
+   desktop, and the CI browser. Hints 8..57 from the floor, legend
+   68..152, chip from 168. */
+@media (max-width:640px){
+  #campus-hints{ left:1.25rem; right:auto; text-align:left; bottom:.5rem; }
+  #campus-legend{ bottom:4.25rem; }
+  #quest{ bottom:10.5rem; }
+}
+/* "drag to orbit · scroll to zoom" describes a mouse, and the keyboard
+   line above it is already gone here — so on a touch screen the whole
+   box is instructions for hardware the visitor does not have. */
+@media (hover:none){ #campus-hints{ display:none; } }
 
 /* ═══════════════ ⑤ THE STUDENT JOURNEY ═══════════════ */
 .jpanel{border:1px solid rgba(212,175,106,.28);border-radius:1rem;
@@ -3439,7 +3475,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v137";
+const BUILD = "pembroke-v138";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -3816,6 +3852,138 @@ window.__shedRung = () => {
   return { rung, done: rung >= LADDER.length };
 };
 
+/* ── the plates give way to each other ──────────────────────────────
+   Eight nameplates hang off eight fixed points in the world. Nothing
+   about them is wrong; what was wrong is that nothing downstream ever
+   reacted to the camera. On a laptop the halls are spread across
+   1280px and the question never comes up. In portrait standBack()
+   pulls the camera 1.5x further out to fit the campus in frame at all,
+   and those same eight anchors land inside a band 138px tall: measured
+   at 393x851, five hall plates in seven overlapping pairs, the Library
+   printing through Drosdick Hall, the Chapel buried under both.
+
+   So: after the camera settles, walk the plates nearest-first and let
+   each one take the pixels it needs, standing down any that would
+   print over a plate already placed. Nearest-first because the
+   renderer has already sorted every plate by distance and written the
+   answer into zIndex — the priority order costs nothing to obtain —
+   and because the near thing is the thing being looked at.
+
+   Deliberately not per frame. Reading a rect forces a layout flush,
+   and the campus is a static camera over a moving crowd: PLATE_SETTLE
+   after anything moves the camera, PLATE_DRIFT otherwise, because
+   people walk out from under their own names. That is ~6Hz at its
+   busiest against 60, and 1Hz at rest. */
+const PLATE_GAP = 3;        /* plates that merely touch still read as a pile */
+/* Everything else that is drawn on the glass over the campus. A plate
+   may not print on any of it. Absent or hidden entries are skipped, so
+   this can name things that only exist in some modes. */
+const HUD_BOXES = ["#campus-wing-intro", "#campus-legend", "#campus-hints",
+                   "#quest", "#minimap", "#daynight", "#walkbtn", "#arr-cta",
+                   "#walkhud", "#doorprompt"];
+const PLATE_SETTLE = 160;   /* after the camera moves: soon, but not per frame */
+const PLATE_DRIFT = 900;    /* with the camera still: often enough for walkers */
+let plateSweepDue = true, plateSweptAt = -1e9;
+/* the sector the objective is currently sending people to, kept fresh
+   by refreshQuest() — see the sort below */
+let questPlate = null;
+function crowdingChanged(){ plateSweepDue = true; }
+
+function sweepPlates(now){
+  plateSweptAt = now;
+  plateSweepDue = false;
+  const host = labelRenderer.domElement;
+  /* A hidden label layer measures every plate as a zero-sized box at
+     the origin, which reads as one enormous pile and would stand all
+     but one of them down — then leave them that way until the next
+     sweep. Nothing to judge here; come back when there is. */
+  if (!host || !host.clientWidth) return;
+  const plates = [];
+  host.querySelectorAll(".hall-tag, .stu-tag").forEach(el => {
+    /* the renderer parks anything off screen or behind the camera at
+       display:none — no box, so it can neither crowd nor be crowded */
+    if (el.style.display === "none") return;
+    plates.push(el);
+  });
+  if (plates.length < 2){
+    plates.forEach(el => {
+      el.classList.remove("crowded-out");
+      el.style.marginTop = "";          /* and put back any nudge it is carrying */
+      el.dataset.dy = 0;
+    });
+    return;
+  }
+  /* Nearest first, with one plate ahead of the whole field: the hall
+     the objective names. Without that exception the first version of
+     this stood the Great Library down at 393px — the campus telling
+     the visitor to walk to a building whose name it had just hidden,
+     which is a worse fault than the pile it was clearing. */
+  const rank = el => (questPlate && el.dataset.sector === questPlate) ? 0 : 1;
+  plates.sort((a, b) => rank(a) - rank(b) ||
+                        (+b.style.zIndex || 0) - (+a.style.zIndex || 0));
+  /* EVERY READ BEFORE EVERY WRITE. Interleaving them makes each write
+     invalidate the layout the next read needs, which turns one flush
+     per sweep into one per plate — the cost this whole design exists
+     to avoid. So: measure the lot, decide arithmetically, then write.
+     Rects come back including whatever nudge the last sweep left on
+     the element, so the offset is taken back off to get the anchor. */
+  const boxes = plates.map(el => {
+    const r = el.getBoundingClientRect();
+    const was = +el.dataset.dy || 0;
+    return { el, x: r.left, y: r.top - was, w: r.width, h: r.height };
+  });
+  /* SEEDED WITH THE INTERFACE, which is not a plate but is certainly in
+     the way. Judging plates only against each other passed a screenshot
+     with "Drosdick Hall" sitting on the words "Click a building to step
+     inside its lecture wing" — no two plates overlapping, and the page
+     still unreadable. Anything already on the glass claims its pixels
+     first; the plates arrange themselves in what is left. */
+  const kept = [];
+  HUD_BOXES.forEach(sel => {
+    const el = document.querySelector(sel);
+    if (!el) return;
+    const cs = getComputedStyle(el);
+    if (cs.display === "none" || cs.visibility === "hidden" || +cs.opacity < 0.05) return;
+    const r = el.getBoundingClientRect();
+    if (r.width && r.height) kept.push({ x: r.left, r: r.right, y: r.top, b: r.bottom });
+  });
+  const free = (x, y, w, h) => !kept.some(k =>
+    x < k.r + PLATE_GAP && k.x - PLATE_GAP < x + w &&
+    y < k.b + PLATE_GAP && k.y - PLATE_GAP < y + h);
+  /* Hiding a plate is the last resort, not the first. A name that
+     cannot sit exactly over its roof can usually sit a little above or
+     below it and still read as that building's name — these anchors
+     already float well clear of the architecture. Standing plates down
+     without trying showed two halls of five on a phone; letting them
+     step aside shows all five.
+     DOWNWARD FIRST, because down is where the building is. Preferring
+     up walked the plates off the sky and onto the masthead copy, which
+     is further from the roof they name and on top of something someone
+     is reading. */
+  const NUDGE = [0, 34, -34, 68, -68, 102, -102];
+  /* A PERSON'S NAME IS NOT A HALL PLATE. A nameplate hangs off a
+     building that fills a good part of the screen, so moving it 100px
+     still reads as that building's name. A student's name hangs over
+     one student's head in a crowd of them, and moved that far it reads
+     as the name of whoever it lands on. Measured: the sweep had pushed
+     "Theo" 102px off Theo. So people get one small step and then stand
+     down — an absent name is honest, a misattributed one is not. */
+  const NUDGE_STU = [0, 16, -16];
+  const plan = boxes.map(b => {
+    for (const dy of (b.el.classList.contains("stu-tag") ? NUDGE_STU : NUDGE))
+      if (free(b.x, b.y + dy, b.w, b.h)){
+        kept.push({ x: b.x, r: b.x + b.w, y: b.y + dy, b: b.y + dy + b.h });
+        return { el: b.el, dy };
+      }
+    return { el: b.el, dy: null };
+  });
+  for (const p of plan){
+    p.el.dataset.dy = p.dy || 0;
+    p.el.style.marginTop = p.dy ? p.dy + "px" : "";
+    p.el.classList.toggle("crowded-out", p.dy === null);
+  }
+}
+
 function resize(){
   const w = stageEl.clientWidth || 800, h = stageEl.clientHeight || 600;
   renderer.setSize(w, h);
@@ -3828,6 +3996,12 @@ function resize(){
   if (!window.__walker?.on) camera.fov = fovFor(camera.aspect);
   camera.updateProjectionMatrix();
   applyFog();                             /* rotating the phone changes the standoff */
+  /* standBack() is a camera decision with a typographic consequence:
+     the further out it stands, the closer together the plates land.
+     This is the only place that knows the aspect changed, so it is
+     where the plates are told. */
+  document.body.classList.toggle("plates-lean", standBack() > 1);
+  crowdingChanged();                      /* and the whole layout must be re-judged */
 }
 window.addEventListener("resize", resize);
 
@@ -5008,6 +5182,7 @@ BUILDINGS.forEach(spec => {
   /* CSS2D nameplate */
   const el = document.createElement("div");
   el.className = "hall-tag";
+  el.dataset.sector = spec.sector;        /* the declutter pass asks which hall this is */
   el.style.setProperty("--glow", S.color);
   el.innerHTML = `<div class="t1"><span class="flag"></span>${S.hall}</div>
     <div class="t2">${S.track}</div>
@@ -5072,6 +5247,7 @@ BUILDINGS.forEach(spec => {
     /* nameplate, in the chapel's gold */
     const el = document.createElement("div");
     el.className = "hall-tag";
+    el.dataset.sector = "cathedral";       /* the declutter pass asks which hall this is */
     el.style.setProperty("--glow", S.color);
     el.innerHTML = `<div class="t1"><span class="flag"></span>${S.hall}</div>
       <div class="t2">${S.track}</div>`;
@@ -11217,6 +11393,8 @@ function engineSetMode(m){
 /* ── aerial orbit controls + hall picking ────────────────────────── */
 const controls = new OrbitControls(camera, renderer.domElement);
 controls.addEventListener("change", () => jOrient("look"));   /* orientation: any look counts */
+/* every orbit and every zoom lands the plates somewhere new */
+controls.addEventListener("change", crowdingChanged);
 controls.target.set(0, 30, 0);
 controls.enableDamping = true;
 controls.dampingFactor = 0.06;
@@ -11733,7 +11911,15 @@ function questInfo(){
            text:`Attend ${next.code} · ${next.title} — walk to ${S.hall}` };
 }
 function refreshQuest(){
-  document.getElementById("quest-text").textContent = questInfo().text;
+  const q = questInfo();
+  document.getElementById("quest-text").textContent = q.text;
+  /* The hall the objective names keeps its nameplate whatever else is
+     crowding the screen — see sweepPlates. Cached here rather than
+     asked for in the sweep: questInfo() walks the catalogue and reads
+     the Journey out of storage, which is nothing once a quest changes
+     and real several times a second. */
+  questPlate = q.sector || null;
+  crowdingChanged();
 }
 
 /* Folding the objective away. It is one sentence that rarely changes, so
@@ -12055,6 +12241,11 @@ renderer.setAnimationLoop(() => {
      out onto has moved on rather than been paused. */
   if (!interiorView){
     labelRenderer.render(world, camera);
+    /* after the render, never before: the sweep judges where the
+       plates actually landed this frame, and the renderer is what puts
+       them there */
+    if (now - plateSweptAt >= (plateSweepDue ? PLATE_SETTLE : PLATE_DRIFT))
+      sweepPlates(now);
     composer.render();
   }
   dbgUpdate(now, dt, raw);

--- a/sw.js
+++ b/sw.js
@@ -39,7 +39,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v137";
+const VERSION = "pembroke-v138";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -490,6 +490,80 @@ try {
   await page.setViewportSize({ width: 1280, height: 800 });
   await page.waitForTimeout(600);
 
+  /* THE NAMEPLATES, AT A PHONE. Eight world-space anchors project into
+     whatever screen the visitor brought, and in portrait standBack()
+     pulls the camera 1.5x out to fit the campus at all — which lands
+     all eight inside a band a phone's width across. Measured on main
+     at 393x851: five hall plates in SEVEN overlapping pairs.
+
+     393x851 on purpose. At the suite's own 1280x800 the halls are
+     spread across the width and the pile never forms, so a check
+     sitting at the default viewport passes against the unfixed code —
+     the same trap the framing check above documents.
+
+     Three things are asserted, and the third is the one that keeps the
+     other two honest: "nothing overlaps" is trivially true of a blank
+     screen, so the count of plates still standing is asserted too. A
+     fix that cleared the pile by hiding the campus would fail here. */
+  await page.setViewportSize({ width: 393, height: 851 });
+  await page.waitForTimeout(1200);          /* a resize, a settle, a sweep */
+  const plates = await page.evaluate(() => {
+    /* crowded-out by class, not by opacity. A plate the sweep has just
+       stood down spends 220ms fading, and reading its opacity mid-fade
+       counts it as on screen — which is how the first version of this
+       check reported two overlapping pairs that were one plate on its
+       way out. The class is the sweep's own verdict and does not
+       depend on catching the right moment. */
+    const shown = el => {
+      const cs = getComputedStyle(el);
+      return el.style.display !== "none" && cs.visibility !== "hidden" &&
+             +cs.opacity > 0.05 && !el.classList.contains("crowded-out");
+    };
+    const box = el => { const r = el.getBoundingClientRect();
+                        return { x: r.left, y: r.top, w: r.width, h: r.height }; };
+    const hit = (a, b) => !(a.x + a.w <= b.x || b.x + b.w <= a.x ||
+                            a.y + a.h <= b.y || b.y + b.h <= a.y);
+    const tags = [...document.querySelectorAll(".hall-tag, .stu-tag")].filter(shown);
+    const rects = tags.map(box);
+    let pairs = 0;
+    for (let i = 0; i < rects.length; i++)
+      for (let j = i + 1; j < rects.length; j++) if (hit(rects[i], rects[j])) pairs++;
+
+    let onHud = 0;
+    ["campus-wing-intro","campus-legend","campus-hints","quest",
+     "minimap","daynight","walkbtn","arr-cta"].forEach(id => {
+      const el = document.getElementById(id);
+      if (!el || !shown(el)) return;
+      const h = box(el);
+      if (h.w && h.h) rects.forEach(r => { if (hit(r, h)) onHud++; });
+    });
+
+    /* and the hall the objective names must not be the one stood down
+       — only asked when it is on screen at all to be stood down */
+    const want = window.__quest().sector;
+    const target = want && document.querySelector(`.hall-tag[data-sector="${want}"]`);
+    const targetOn = !target || target.style.display === "none" ? null : shown(target);
+
+    const legend = document.getElementById("campus-legend");
+    const hints  = document.getElementById("campus-hints");
+    const clash = legend && hints && shown(legend) && shown(hints)
+                  ? hit(box(legend), box(hints)) : false;
+    return { visible: tags.length, pairs, onHud, want, targetOn, clash,
+             lean: document.body.classList.contains("plates-lean") };
+  });
+  step("nameplates do not print over each other on a phone",
+       plates.lean && plates.visible >= 2 && plates.pairs === 0,
+       `${plates.visible} plate(s) standing · ${plates.pairs} overlapping pair(s)` +
+       (plates.lean ? "" : "  (the portrait collapse never engaged)"));
+  step("nor over the interface they float above", plates.onHud === 0,
+       plates.onHud + " plate(s) on the HUD");
+  step("and the hall the objective names keeps its name",
+       plates.targetOn !== false,
+       plates.targetOn === null ? `${plates.want} is off screen` : `${plates.want} still reads`);
+  step("the sector legend and the control hints keep apart", !plates.clash);
+  await page.setViewportSize({ width: 1280, height: 800 });
+  await page.waitForTimeout(600);
+
   step("walk mode engages again", await pressUntil("f", () => window.__walker.on === true));
 
   /* The drop point, tested against every wall. v94 shipped with the


### PR DESCRIPTION
Closes #66.

Eight nameplates hang off eight fixed points in the world, and nothing downstream ever reacted to the camera. On a laptop the halls are spread across 1280px and the question never arises. In portrait `standBack()` pulls the camera 1.5× further out to fit the campus in frame at all, and those same anchors land inside a band 138px tall.

Measured at 393×851 on `main`: **five hall plates in seven overlapping pairs**, the Library printing through Drosdick Hall, the Chapel buried under both, the legend across the control hints, the objective chip on the legend's first row.

| | before | after |
|---|---|---|
| hall plates on screen | 5, illegible | 5, all readable |
| overlapping pairs | 7 | 0 |
| plates on the intro copy / minimap | — | 0 |
| legend × hints | overlapping | clear |

## Three things

**Collapse.** Portrait drops the track line and the tally, exactly as walk mode already does, leaving the name and the sector flag. Three lines apiece is three times the area to collide with, and the track sets at 7.5px, which is not type anybody reads at that scale. 57px plates become 32px.

**Place, don't just hide.** After the camera settles, walk the plates and let each take the pixels it needs. A plate that cannot sit over its roof steps a little above or below and still reads as that building's name; only a plate that can find nowhere stands down. Hiding without trying showed **two** halls of five — placing shows all five. Downward first, because down is where the building is.

The sweep is **seeded with the interface**, not just the other plates. Judging plates against each other alone passed a screenshot with "Drosdick Hall" printed across the words *"Click a building to step inside its lecture wing"* — no two plates overlapping, page still unreadable.

The **hall the objective names outranks the whole field**. Without it, the first version stood the Great Library down: the campus telling a visitor to walk to a building whose name it had just hidden, which is worse than the pile it cleared.

**Not per frame.** Reading a rect forces a layout flush, so the sweep runs 160ms after the camera moves and 900ms otherwise, and every read happens before every write so one flush covers the pass. The priority order costs nothing to obtain — `CSS2DRenderer` already sorts every label by distance and writes the answer into `zIndex`.

## And the bottom corners

The legend, the hints and the objective chip are three separately-anchored boxes, none aware of the others. Below 640px they become a stack up the left edge. "Drag to orbit · scroll to zoom" describes a mouse and is dropped on touch, where the keyboard line beside it was already gone.

## What measurement alone missed

The rects said zero overlaps while the screenshot showed plates across the masthead copy. Looking at it is how the HUD seeding and the downward preference were found. Three more, each caught by a check rather than by me:

- **Two "overlapping pairs" were one plate mid-fade.** The sweep had already stood the Chapel down; the check read computed opacity 140ms into a 220ms fade. It now reads the sweep's own verdict, which does not depend on catching the right moment.
- **The legend still overprinted the hints** — in the suite, never in my probe. The probe passed `hasTouch`, which makes `hover:none` match and removes the hints box entirely; a real desktop and the CI browser render it two lines tall at 49px. I had estimated "one or two 10px rows" instead of measuring. The check passed because the thing under test wasn't on screen.
- **Student names were being pushed up to 102px off their heads.** A hall plate can move that far and still read as that building's name; a person's name moved that far reads as whoever it lands on. People get one 16px step and then stand down — an absent name is honest, a misattributed one is not.

## Verification

Full suite green locally — **61 checks**. The four new ones run at 393×851 on purpose; at the suite's own 1280×800 the pile never forms and a check there passes against the unfixed code, the same trap the walk-mode framing check documents.

```
  ok   nameplates do not print over each other on a phone  — 4 plate(s) standing · 0 overlapping pair(s)
  ok   nor over the interface they float above  — 0 plate(s) on the HUD
  ok   and the hall the objective names keeps its name  — lib still reads
  ok   the sector legend and the control hints keep apart
```

The count of plates standing is asserted alongside the overlap count, because "nothing overlaps" is trivially true of a blank screen.

Verified in the negative — sweep, collapse and stack all removed:

```
 FAIL  nameplates do not print over each other on a phone  — 8 plate(s) standing · 6 overlapping pair(s)
 FAIL  nor over the interface they float above  — 3 plate(s) on the HUD
  ok   and the hall the objective names keeps its name  — lib still reads
 FAIL  the sector legend and the control hints keep apart
```

The third passing there is correct and worth stating plainly: it guards against a regression **this fix** could introduce, not against the original bug, so unfixed code — which hides nothing — satisfies it.

## Not done here

The plates float well above their buildings in portrait. That is the aerial anchor heights being tuned for a landscape camera, it is identical before and after this change (both screenshots confirm), and moving them is a separate piece of work.

`ASSETS_V` untouched — no asset changed.

---
_Generated by [Claude Code](https://claude.ai/code/session_015tRByiWBDEj14qa2P4KAgj)_