### PR TITLE
v140: the depot can be invalidated, and the test can see it

### DIFF
--- a/.github/workflows/materials.yml
+++ b/.github/workflows/materials.yml
@@ -67,7 +67,12 @@ jobs:
           done
 
       - name: And now?
-        run: node tools/check-materials.mjs || true
+        # NOT `|| true`. The pre-conversion scan above is a diagnostic and
+        # is allowed to be noisy; this one is the verification, and forcing
+        # it to succeed let the job go green with deprecated spec-gloss
+        # materials still in place — which reaches the campus as white,
+        # untextured characters and is committed by this workflow itself.
+        run: node tools/check-materials.mjs
 
       - name: Did any model actually change?
         id: diff

--- a/index.html
+++ b/index.html
@@ -3488,7 +3488,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v139";
+const BUILD = "pembroke-v140";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */

--- a/sw.js
+++ b/sw.js
@@ -29,6 +29,12 @@
  * redirect cannot legally be returned from a worker, and CDNs redirect.
  * A script that dies that way takes the whole page with it.
  *
+ * Three things can happen to an asset and they need three different
+ * answers, which is why there are three lists rather than one version:
+ * a NEW file needs nothing (cacheFirst simply fetches it once), a
+ * DELETED file needs RETIRED, and a file CHANGED IN PLACE needs
+ * REFRESHED. Only a mass change is worth re-versioning ASSETS_V.
+ *
  * VERSION tracks the RELEASE and versions only the shell. It used to
  * prefix the model depot too, which meant every release — however
  * text-only — flushed the whole model cache and made a returning
@@ -60,6 +66,26 @@ const RETIRED = [
   "./assets/cathedral2.glb",
   "./assets/vendor/spark/spark.module.min.js",
   "./assets/vendor/three-mesh-bvh/index.module.js",
+];
+/* Files whose BYTES changed at a URL the depot already holds. This is
+   the one case neither VERSION nor RETIRED covers, and it is the one
+   with no symptom: cacheFirst matches the stored copy and never asks
+   again, so a corrected model, a re-exported texture or a fixed splat
+   reaches every new visitor and no returning one — forever, and it
+   looks right on the machine of whoever made the change, because their
+   own browser fetched it fresh.
+
+   Bumping ASSETS_V would also fix it and is the wrong trade for one
+   file: it throws away the whole ~85MB depot a returning visitor
+   already holds. Named refresh drops exactly the changed entries on
+   activate and lets cacheFirst re-fetch them, which is what RETIRED
+   does for deletion and for the same reason.
+
+   An entry may leave this list once no plausible visitor still holds
+   the old bytes. tools/check-sw-version.sh fails the build when an
+   asset is modified in place and named in neither this list nor a
+   fresh ASSETS_V. */
+const REFRESHED = [
 ];
 const SHELL = VERSION + "-shell";
 const DEPOT = ASSETS_V + "-depot";
@@ -160,7 +186,8 @@ self.addEventListener("activate", (e) => {
        the activation down with it. */
     try {
       const depot = await caches.open(DEPOT);
-      await Promise.all(RETIRED.map((u) => depot.delete(u, { ignoreVary: true })));
+      await Promise.all([...RETIRED, ...REFRESHED]
+        .map((u) => depot.delete(u, { ignoreVary: true })));
     } catch (_) {}
     await self.clients.claim();
   })());

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v139";
+const VERSION = "pembroke-v140";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/check-sw-version.sh
+++ b/tools/check-sw-version.sh
@@ -2,13 +2,26 @@
 #
 # Pembroke Academy — guard against shipping stale models.
 #
-# The service worker caches everything under assets/ cache-first, keyed
-# by VERSION in sw.js. Change a model without bumping VERSION and every
-# returning visitor keeps the old one indefinitely, with no symptom you
-# would ever notice locally: your own browser holds the new files, so
-# the site looks correct to you and is broken for everybody else.
+# The service worker caches everything under assets/ cache-first, in a
+# depot keyed by ASSETS_V — NOT by VERSION. This guard used to demand a
+# VERSION bump for any asset change, which was right when VERSION
+# prefixed the depot too and has been wrong since it stopped: the
+# release workflows dutifully bump VERSION, the guard passes, the depot
+# name never moves, and cacheFirst keeps handing back the old bytes.
 #
-# That is a silent, sticky, user-facing failure, so it is worth a check.
+# Three things can happen to an asset and only one of them is a
+# problem:
+#
+#   added    a URL the depot has never held — cacheFirst fetches it
+#            once. Nothing to do.
+#   deleted  cacheFirst simply stops asking, so the bytes sit on the
+#            visitor's disk forever. sw.js RETIRED names them.
+#   changed  the depot holds that URL already and will never ask again.
+#            sw.js REFRESHED names them, or ASSETS_V moves.
+#
+# The last one has no symptom whatsoever: your own browser fetched the
+# new file, so the site looks correct to you and is stale for everybody
+# who was here before. That is what this guard is for.
 #
 #   bash tools/check-sw-version.sh <base-ref>
 #
@@ -45,35 +58,57 @@ if [ "$build" != "$version" ]; then
 fi
 echo "BUILD and VERSION agree at $build"
 
-changed_assets="$(git diff --name-only "$base"...HEAD -- assets/ | grep -viE '\.md$' || true)"
-if [ -z "$changed_assets" ]; then
-  echo "no asset changes — VERSION bump not required"
+# --diff-filter=M: modified in place. Added (A) files are safe by
+# construction and deleted (D) ones are RETIRED's business, so neither
+# belongs in the check that follows.
+modified="$(git diff --name-only --diff-filter=M "$base"...HEAD -- assets/ | grep -viE '\.md$' || true)"
+if [ -z "$modified" ]; then
+  echo "no asset changed in place — the depot still describes what it holds"
   exit 0
 fi
 
-old="$(git show "$base:sw.js" 2>/dev/null | sed -n 's/^const VERSION = "\(.*\)";$/\1/p')"
-new="$(sed -n 's/^const VERSION = "\(.*\)";$/\1/p' sw.js)"
-
-if [ -z "$new" ]; then
-  echo "could not read VERSION from sw.js — the guard cannot vouch for this change"
+old_av="$(git show "$base:sw.js" 2>/dev/null | sed -n 's/^const ASSETS_V = "\(.*\)";$/\1/p')"
+new_av="$(sed -n 's/^const ASSETS_V = "\(.*\)";$/\1/p' sw.js)"
+if [ -z "$new_av" ]; then
+  echo "could not read ASSETS_V from sw.js — the guard cannot vouch for this change"
   exit 1
 fi
 
-# sw.js is new on this branch: nothing cached under an older key, so fine.
-if [ -z "$old" ]; then
-  echo "sw.js is new here — no previous cache to invalidate"
+# A moved ASSETS_V renames the whole depot, so every stale entry goes
+# with it. Blunt, but it is a legitimate answer for a mass change.
+if [ -n "$old_av" ] && [ "$old_av" != "$new_av" ]; then
+  echo "assets changed in place and ASSETS_V moved $old_av -> $new_av (whole depot re-keyed)"
   exit 0
 fi
 
-if [ "$old" = "$new" ]; then
+# Otherwise each modified file must be named in REFRESHED. Read the
+# list as the literal block it is, so a path mentioned in a comment
+# somewhere else in sw.js cannot vouch for a file.
+refreshed="$(sed -n '/^const REFRESHED = \[/,/^\];/p' sw.js)"
+unnamed=""
+while IFS= read -r f; do
+  [ -n "$f" ] || continue
+  case "$refreshed" in
+    *"\"./$f\""*) ;;
+    *) unnamed="$unnamed$f
+" ;;
+  esac
+done <<< "$modified"
+
+if [ -n "$unnamed" ]; then
   echo
-  echo "assets changed but sw.js VERSION is still '$new'."
+  echo "these assets changed in place but are named in neither REFRESHED nor a new ASSETS_V:"
   echo
-  echo "$changed_assets" | sed 's/^/    /'
+  printf '%s' "$unnamed" | sed 's/^/    /'
   echo
-  echo "Returning visitors would keep the old files forever. Bump VERSION"
-  echo "in sw.js (e.g. pembroke-v2) so the worker drops its old caches."
+  echo "The depot already holds those URLs and cacheFirst never asks again,"
+  echo "so every returning visitor keeps the old bytes indefinitely — and it"
+  echo "looks correct on your machine, because your browser fetched the new"
+  echo "ones. Add them to REFRESHED in sw.js (activate drops exactly those"
+  echo "entries and the next fetch re-fills them), or bump ASSETS_V if the"
+  echo "change is broad enough to be worth re-keying the whole depot."
   exit 1
 fi
 
-echo "assets changed and VERSION moved $old -> $new"
+echo "assets changed in place and every one is named in REFRESHED"
+exit 0

--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -776,14 +776,20 @@ try {
      one run, 25 cached the next — so wait for the depot to actually hold
      what visit 1 fetched before judging it. */
   const settled = await page.waitForFunction(async (paths) => {
-    const key = (await caches.keys()).find(k => k.endsWith("-assets"));
+    /* "-depot", not "-assets": the depot was renamed when release and
+       asset versions were split, and this selector was not. It matched
+       nothing, so stillCached came back empty, and the assertion below
+       — "none of the models we still hold were refetched" — passed
+       having recognised none of them. A test that cannot fail is worse
+       than no test, because it is counted. */
+    const key = (await caches.keys()).find(k => k.endsWith("-depot"));
     if (!key) return null;
     const cache = await caches.open(key);
     for (const p of paths) if (!(await cache.match(p))) return null;
     return true;
   }, [...firstVisit], { timeout: 120_000 }).then(() => true, () => false);
   step("first visit finishes caching what it fetched", settled,
-       settled ? firstVisit.size + " model(s) in the cache"
+       settled ? firstVisit.size + " model(s) fetched and matched in the depot"
                : "gave up waiting — the next check will show what is missing");
 
   /* Deliberately NOT waiting for the outer world to finish first. Tried
@@ -808,15 +814,29 @@ try {
      happens. Failing on eviction would be blaming the worker for the
      browser's decision — so measure what is actually still cached, and
      judge only that. */
-  const stillCached = await page.evaluate(async (paths) => {
-    const key = (await caches.keys()).find(k => k.endsWith("-assets"));
-    if (!key) return [];
+  /* null means the depot is not there at all, which is a different
+     thing from an empty one and must not be reported as eviction. */
+  const held = await page.evaluate(async (paths) => {
+    const key = (await caches.keys()).find(k => k.endsWith("-depot"));
+    if (!key) return null;
     const cache = await caches.open(key);
     const out = [];
     for (const p of paths) if (await cache.match(p)) out.push(p);
     return out;
   }, [...firstVisit]).catch(() => [...firstVisit]);
 
+  /* The worker's contract is that a depot exists and anything still in
+     it is served from it. Eviction is the browser's decision and is
+     forgiven; a missing depot is not, and used to be indistinguishable
+     from it — this returned [] for both, so "none of the models we
+     still hold were refetched" passed having recognised none of them.
+     Report the two apart, and say the count that was actually measured
+     rather than the count that was served. */
+  step("the model depot survives a reload", held !== null,
+       held === null ? "no cache whose name ends in -depot — the worker cached nothing"
+                     : `${held.length} of ${firstVisit.size} first-visit model(s) still held`);
+
+  const stillCached = held ?? [];
   const evicted = firstVisit.size - stillCached.length;
   const cachedSet = new Set(stillCached);
   const refetched = servedModels.filter(p => cachedSet.has(p));


### PR DESCRIPTION
Closes #101. Closes part of #107 (PE-24A and PE-27A; PE-25 and PE-26 remain open).

**Smoke: 62 checks, all passed. Ledger probe: 6, all passed.**

---

## The hole

Three things can happen to an asset and they need three different answers:

| | | |
|---|---|---|
| **added** | a URL the depot never held | `cacheFirst` fetches it once — nothing to do |
| **deleted** | never asked for again | `RETIRED` names it — already existed |
| **changed in place** | the depot holds that URL and will never ask again | **nothing at all** |

The third has no symptom. A corrected model reaches every new visitor and no returning one, forever, and looks right on the machine of whoever changed it because their browser fetched it fresh.

`REFRESHED` names those files; activate drops exactly those entries and the next fetch re-fills them. Same trade `RETIRED` already makes, for the same reason. Bumping `ASSETS_V` also works and stays available for a mass change — it is just the wrong price for one file, since it discards the whole ~85 MB depot a returning visitor holds.

## The guard was enforcing the retired design

It demanded a `VERSION` bump for *any* asset change. That was right while `VERSION` prefixed the depot and has been wrong since the split: the release workflows bump `VERSION`, the guard passes, the depot name never moves.

It now asks the question that matters, of the files it matters for. Five cases, each checked by hand:

```
change in place, named nowhere      → exit 1   ✅ (the fault)
change in place, named in REFRESHED → exit 0
add a new asset                     → exit 0
delete an asset                     → exit 0   (RETIRED's business)
change in place, ASSETS_V bumped    → exit 0
```

`REFRESHED` ships empty, which is correct — this release changes no asset in place, and the guard says so.

## The test that should have caught it

It looked for a cache whose name ends in `-assets`. The depot has been `pembroke-assets-v3-depot` since the split, so the selector matched nothing, `stillCached` came back empty, and *"none of the models we still hold were refetched"* passed having recognised none of them.

The misleading part is what it printed:

```
before   re-downloads nothing it still has — 0 model(s) served from cache
                                             (36 evicted by the browser before the reload)
after    the model depot survives a reload — 37 of 37 first-visit model(s) still held
         re-downloads nothing it still has — 37 model(s) served from cache
```

**Nothing was ever evicted.** The cache had been working the whole time; the check could not see it and offered an explanation for its own blindness. A missing depot and an empty one now give different answers, so eviction stays forgiven — it is the browser's call — while a depot that isn't there fails.

## Also — a gate that could not fail

`materials.yml` ran its **post-conversion verification** under `|| true`, so the job went green with deprecated spec-gloss materials still in place and committed white, untextured characters. The pre-conversion scan keeps its `|| true`; it is a diagnostic. The verification does not.

---

## Notes for review

- **`REFRESHED` is a list somebody has to remember to add to.** That is the same shape as `RETIRED` and I kept it deliberately — the guard fails the build when it is forgotten, which is what makes the list survivable. Content-addressed asset URLs would remove the need entirely and are the better long-term answer; that is a larger change than this.
- I tried to reproduce the broken selector's behaviour in isolation and got a result I could not explain (the `-assets` form appeared to resolve truthy in a standalone harness). I did not chase it further, and the fix does not rest on it: it rests on the observed cache names — `pembroke-v139-shell` and `pembroke-assets-v3-depot`, with `endsWith("-assets")` matching neither — and on the before/after above.
- Still open from #107: **PE-25** (no hermetic Worker suite; `check-gateway.mjs` is manual and hits production) and **PE-26** (no mobile or accessibility gate anywhere in CI — the gap that let the mobile-only and a11y-only defects ship).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_