### PR TITLE
v144: nothing acts on the campus without owning it — and the governor answers for the object

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -360,3 +360,51 @@ jobs:
 
       - name: Can this campus be used without a mouse?
         run: node tools/check-a11y.mjs
+
+  # ── who owns the keyboard, and whose turn is it? ────────────────────
+  # One question asked twice. Input and async continuations both act on
+  # the campus, and neither used to check who currently holds it: four
+  # global key listeners each knew its own mode and none knew the
+  # overlay stack, and a finished AI turn wrote its line, gesture, call
+  # to action, speech and focus to a surface it never re-checked it
+  # still owned.
+  #
+  # The second half never misbehaved in practice, because convoClose()
+  # aborts and the abort beat the continuation every time — safety
+  # resting on an ordering nothing enforced. The probe installs a
+  # provider that IGNORES abort, which is the case that ordering does
+  # not cover and the one a real provider cannot be asked to perform.
+  owner:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache the browser
+        id: browser
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PW_VERSION }}
+
+      - name: Install Playwright
+        timeout-minutes: 6
+        run: npm install --no-save --no-audit --no-fund playwright@${{ env.PW_VERSION }}
+
+      - name: Fetch the browser
+        if: steps.browser.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
+
+      - name: System libraries for the cached browser
+        if: steps.browser.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
+
+      - name: Does anything act on the campus without owning it?
+        run: node tools/check-owner.mjs

--- a/index.html
+++ b/index.html
@@ -3592,7 +3592,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v143";
+const BUILD = "pembroke-v144";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -6767,7 +6767,8 @@ const STUDENT_ROSTER = [
   /* Tier 1: the MATH 201 professor. He stands by his own hall's door
      and teaches to the student's actual frontier in the course — the
      mastery data says what to affirm and what to revisit. */
-  { name:"Prof. Merion", ai:{ cls:"professor", year:"professor of mathematics", pron:"he/him", traits:["exacting but kind","allergic to hand-waving","believes every formula is a picture first"], style:"a lecturer's clarity at conversation volume; asks what you SEE before what you compute" },
+  { name:"Prof. Merion", ai:{ cls:"professor", year:"professor of mathematics", pron:"he/him",
+      role:"the MATH 201 (Applied Calculus) professor at Pembroke Academy", traits:["exacting but kind","allergic to hand-waving","believes every formula is a picture first"], style:"a lecturer's clarity at conversation volume; asks what you SEE before what you compute" },
     /* looks follows the body, for the same reason it does on the Dean:
        it is read only to pick a stand-in in the seconds before the
        pinned body lands, and a stale value there puts the wrong person
@@ -6788,7 +6789,8 @@ const STUDENT_ROSTER = [
      wrong basis, on a campus where a visitor may be told about the Dean
      by somebody else. Optional: a character without it simply has
      nothing said about theirs. */
-  { name:"Dean Aldergate", ai:{ cls:"advisor", year:"dean of students", pron:"she/her", traits:["courtly","attentive","quietly funny","remembers everyone"], style:"warm and unhurried, an old-fashioned advisor's cadence; asks one good question at a time" },
+  { name:"Dean Aldergate", ai:{ cls:"advisor", year:"dean of students", pron:"she/her",
+      role:"the Dean of Students and academic advisor at Pembroke Academy", traits:["courtly","attentive","quietly funny","remembers everyone"], style:"warm and unhurried, an old-fashioned advisor's cadence; asks one good question at a time" },
     /* looks follows the body. It is read only to pick a stand-in if the
        pinned one has not arrived, so a stale "m" here would put a man on
        the Administration apron in the seconds before char17 lands — the
@@ -15242,7 +15244,15 @@ function aiSystemPrompt(s, userText){
     ].join(" ");
   })() : "";
   return [
-    `You are ${d.name}, a ${ai.year || "student"} at Pembroke Academy studying ${d.major}. You are a person in this world, never an assistant: no "how can I help you today", no mention of being an AI, no offers of general assistance. You are mid-walk on campus having a chat.`,
+    /* A role where the student sentence does not fit. "a ${year} at
+       Pembroke Academy studying ${major}" is right for a sophomore and
+       wrong for everyone who teaches: it produced "a dean of students
+       at Pembroke Academy studying Academic Advising" and "a professor
+       of mathematics ... studying Applied Calculus". The hosted Worker
+       never had this, because its registry carries a role string per
+       character — this is the browser's copy of that prompt catching
+       up, which is the same lag PE-16 was. */
+    `You are ${d.name}, ${ai.role || `a ${ai.year || "student"} at Pembroke Academy studying ${d.major}`}. You are a person in this world, never an assistant: no "how can I help you today", no mention of being an AI, no offers of general assistance. You are mid-walk on campus having a chat.`,
     `Personality: ${(ai.traits || []).join(", ")}.${ai.pron ? ` Your pronouns are ${ai.pron}.` : ""} Voice: ${ai.style}. Keep replies to 1-3 short sentences${ai.cls === "academic" ? ", except when actually teaching a concept — then up to 6, always concrete, image-first" : ""}. Contractions, hesitations, opinions welcome.`,
     `Knowledge boundaries: ${knowledge}`,
     `Where you are: ${aiPlaceOf(s.pos)}, ${aiClock()}. Your home hall is ${hall ? hall.hall : "the quad"}. You are currently ${s.inside ? "just out of a lecture" : s.mode === "todoor" || s.route ? "walking to a class" : "out on the paths"}.`,
@@ -15561,8 +15571,22 @@ function aiGovern(intent, s){
   const cls = s?.data?.ai?.cls || "social";
   /* authorization first, from the one table — an intent a role may not
      propose dies here regardless of how plausible it looks */
-  if (!(AI_POLICY[cls] || AI_POLICY.social).includes(intent.type)) return null;
-  if (intent.type === "point_to_location" && SECTORS[intent.target])
+  /* hasOwn on both, because a bracket lookup answers for the prototype
+     as well as the object. SECTORS["__proto__"] is truthy and its
+     .hall is undefined, so a model proposing point_to_location with
+     that target used to render "(points toward undefined)". And
+     AI_POLICY["__proto__"] is Object.prototype, which is truthy — so
+     the `|| AI_POLICY.social` fallback would NOT catch it and
+     .includes would throw instead. cls comes from the campus rather
+     than the model, so that second one is defence in depth; the rule
+     is easier to keep when it has no exceptions.
+
+     The same lookup on the same object was already corrected at the
+     sector restore (see LS_SECTOR) while this one was left, which is
+     what filing a bug and fixing its twin elsewhere looks like. */
+  const policy = Object.hasOwn(AI_POLICY, cls) ? AI_POLICY[cls] : AI_POLICY.social;
+  if (!policy.includes(intent.type)) return null;
+  if (intent.type === "point_to_location" && Object.hasOwn(SECTORS, intent.target ?? ""))
     return { caption: `(points toward ${SECTORS[intent.target].hall})` };
   if (intent.type === "end_conversation")
     return { caption: "(seems ready to get going)" };

--- a/index.html
+++ b/index.html
@@ -3592,7 +3592,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v142";
+const BUILD = "pembroke-v143";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -11927,8 +11927,33 @@ function walkUpdate(dt){
   dp.classList.toggle("show", !!walker.door);
   if (walker.door) document.getElementById("doorprompt-name").textContent = "Enter " + SECTORS[walker.door].hall;
 }
+/* ── who owns the keyboard ───────────────────────────────────────────
+   Four global listeners each knew its own mode and none knew the
+   overlay stack. With the application dialog open and focus on a
+   <select>, pressing 2, f, n changed the sector and entered
+   first-person walk mode BEHIND a dialog that stayed open — the
+   editable-target test covered input and textarea, a <select> is
+   neither, and no handler asked whether anything was open.
+
+   The accessibility work made this look solved without solving it:
+   the background is genuinely inert now, so a keyboard cannot REACH
+   the campus behind a dialog. inert does nothing about a listener
+   bound to window, which receives the key wherever it was pressed.
+   A surface that looks sealed and is not is worse than one that
+   looks open.
+
+   An interior is not an owner: it is a campus view, and switching
+   sector from inside a hall closes it on the way, which is coherent
+   and worth keeping. A dialog and a conversation are owners. */
+const EDITABLE = "input,textarea,select,[contenteditable]:not([contenteditable='false'])";
+function campusHasKeyboard(e){
+  if (e.target?.matches?.(EDITABLE)) return false;
+  if (jmodal.classList.contains("open")) return false;
+  if (convoView) return false;
+  return true;
+}
 window.addEventListener("keydown", e => {
-  if (e.target.matches("input,textarea")) return;
+  if (!campusHasKeyboard(e)) return;
   if (e.key === "f" || e.key === "F"){ walker.on ? exitWalk() : enterWalk(); return; }
   if (!walker.on) return;
   walker.keys[e.code] = true;
@@ -14130,12 +14155,18 @@ function selectSector(key, fromCampus){
 
 /* keyboard wayfinding: 1–4 quads, 0 full syllabus, P people and places */
 window.addEventListener("keydown", (e) => {
-  if (e.target.matches("input,textarea")) return;
+  /* Escape belongs to the innermost thing that is open: a conversation
+     closes itself, a dialog closes itself, and only when neither owns
+     the keyboard does Escape mean "leave this hall". The first draft
+     of this let Escape through while a dialog was up, which would have
+     closed the hall BEHIND the dialog — the exact bug one line above
+     it was fixing. */
+  if (!campusHasKeyboard(e)) return;
+  if (e.key === "Escape"){ closeInterior(); return; }
   const map = { "1":"lib", "2":"eng", "3":"sci", "4":"adm", "0":"all" };
   if (map[e.key]) selectSector(map[e.key], true);
   if (e.key === "n" || e.key === "N") document.getElementById("daynight").click();
   if (e.key === "p" || e.key === "P") nearbyToggle();
-  if (e.key === "Escape") closeInterior();
 });
 
 /* ── the keyboard's way in ───────────────────────────────────────────
@@ -14421,6 +14452,13 @@ const interiorEl = document.getElementById("interior");
    filter and no second pass. It costs one texture and it means you are
    still visibly standing on the quad instead of in a void. */
 let convoView = null;                  /* the student record, or null */
+/* Bumped on every open and every close. A turn takes its value when it
+   starts and checks it after every await: the safety here used to rest
+   entirely on convoClose()'s abort beating the continuation, so any
+   provider that ignores abort, any close that does not abort, or a slow
+   enough resolution would put one student's words, gesture, call to
+   action, history and focus into the next student's conversation. */
+let convoGen = 0;
 let convoLook = null;                  /* the head bone and its neutral, or null */
 let convoScene = null, convoCam = null, convoRT = null, convoHome = null, convoBase = null;
 let convoHomeCull = [];
@@ -14777,7 +14815,7 @@ function convoOpen(s){
   convoCam.position.set(convoBase.x, eye, dist);
   convoCam.lookAt(0, convoBase.lookY, 0);
 
-  convoView = s;
+  convoView = s; convoGen++;
   convoSay(s, null);
   convoEl.classList.add("open");
   convoEl.setAttribute("aria-hidden", "false");
@@ -14822,7 +14860,7 @@ function convoClose(){
      has gone back to the lawn would keep correcting a head nobody is
      looking at, and keep the body alive after it should be collectable. */
   convoLook = null;
-  convoView = null; convoHome = null;
+  convoView = null; convoHome = null; convoGen++;
   convoEl.classList.remove("open");
   /* inert alongside aria-hidden, always: aria-hidden alone told the
      screen reader the panel was gone while leaving its input, send,
@@ -14925,6 +14963,11 @@ function aiWireConvo(s){
     const text = input.value.trim();
     if (!text) return;
     if (AIQueue.busy){ input.value = text; return; }   /* still talking — keep the words */
+    /* Taken before the first await and checked after every one. Both
+       halves matter: the generation catches a close-and-reopen of the
+       SAME student, which convoView === s alone would wave through. */
+    const gen = convoGen;
+    const mine = () => gen === convoGen && convoView === s;
     input.value = "";
     document.getElementById("convo-said").textContent = "…";
     think.hidden = false; row.hidden = true;
@@ -14934,6 +14977,7 @@ function aiWireConvo(s){
     const saidLive = document.getElementById("convo-said");
     try {
       out = await aiGenerate(s, text, s.aiHist, d => {
+        if (!mine()) return;        /* tokens arriving for a conversation that has ended */
         think.hidden = true;                 /* words beat the spinner */
         saidLive.textContent = d;
       });
@@ -14946,6 +14990,13 @@ function aiWireConvo(s){
          " (the AI service is unreachable — canned dialogue still works below)"),
         emotion: "distracted", intent: { type: "none" }, fallback: true };
     }
+    /* Everything below writes to the ONE conversation surface, so if
+       this turn is no longer the open one, it writes nothing at all —
+       not the line, not the gesture, not the call to action, not the
+       history, not the speech, not the focus. The surface it would
+       have written to already belongs to somebody else, and
+       aiGenerate's finally has already released the queue. */
+    if (!mine()) return;
     think.hidden = true; row.hidden = false;
     const saidEl = document.getElementById("convo-said");
     saidEl.textContent = out.dialogue || "…";
@@ -15564,7 +15615,12 @@ function aiExtractMemories(name, transcript){
       NPCStore.remember(name, `The visitor said: "${x.slice(0, 140)}"`, Math.min(0.9, 0.4 + x.length / 300));
   }
 }
-window.__ai = { AI, NPCStore, AIQueue, aiParse, aiGovern, aiCourseFacts, aiSystemPrompt, aiHostedHealth: (...a) => aiHostedHealth(...a) };   /* test/debug hook */
+/* test/debug hook. AIProviders is here so a probe can install a
+   provider that IGNORES abort — the ordering the old code was relying
+   on without saying so, and the one thing a real provider cannot be
+   asked to do on demand. */
+window.__ai = { AI, NPCStore, AIQueue, AIProviders, aiParse, aiGovern, aiCourseFacts, aiSystemPrompt,
+                aiHostedHealth: (...a) => aiHostedHealth(...a), gen: () => convoGen };   /* test/debug hook */
 window.__talkTo = (name) => {          /* test/debug hook: pull a named persona into conversation */
   const s = students.find(s => s.data?.name === name && s.pos);
   if (s) convoOpen(s);

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v143";
+const VERSION = "pembroke-v144";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v142";
+const VERSION = "pembroke-v143";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/check-owner.mjs
+++ b/tools/check-owner.mjs
@@ -129,7 +129,56 @@ try {
     !document.getElementById("jmodal").classList.contains("open"));
   step("but the dialog's own Escape still closes it", shut);
 
-  /* ── 2. a turn that is no longer the turn writes nothing ─────────
+  /* ── 2. the governor answers for the object, not its prototype ───
+     A bracket lookup answers for the prototype too, so SECTORS
+     ["__proto__"] is truthy and its .hall is undefined: the caption
+     used to read "(points toward undefined)". Fail-closed either way —
+     no state moves — but it is a lookup that says yes to a key nobody
+     put there, and the same lookup on the same object was already
+     corrected at the sector restore while this one was left. */
+  /* Its own try, because the failure this guards against is a THROW,
+     not a wrong answer: AI_POLICY["__proto__"] resolved to
+     Object.prototype and .includes on it is not a function. Left
+     unattributed it took the whole probe down and reported as
+     "ownership check completed", which names nothing. */
+  const gov = await page.evaluate(() => {
+    const { aiGovern } = window.__ai;
+    const who = (cls) => ({ data: { name: "probe", ai: { cls } } });
+    const cap = (r) => r?.caption ?? null;
+    return {
+      real:   cap(aiGovern({ type: "point_to_location", target: "lib" }, who("social"))),
+      proto:  cap(aiGovern({ type: "point_to_location", target: "__proto__" }, who("social"))),
+      ctor:   cap(aiGovern({ type: "point_to_location", target: "constructor" }, who("social"))),
+      none:   cap(aiGovern({ type: "point_to_location" }, who("social"))),
+      /* A role reaching past its own table. An UNKNOWN class falling
+         back to AI_POLICY.social is by design and is the safe
+         direction — social is the least-privileged table — so the
+         question is not whether "__proto__" may point at a hall (it
+         may, as any stranger may) but whether it inherits anything
+         more. Before this was hasOwn, AI_POLICY["__proto__"] resolved
+         to Object.prototype, which is truthy, so the `|| social`
+         fallback never fired and .includes threw instead. */
+      overreach:     aiGovern({ type: "open_registration" }, who("social")),
+      protoPoints:   aiGovern({ type: "point_to_location", target: "lib" }, who("__proto__")),
+      protoEscalate: aiGovern({ type: "open_registration" }, who("__proto__")),
+    };
+  }).catch(e => ({ threw: e.message.split("\n")[0] }));
+  if (gov.threw){
+    step("the governor points only at halls that exist", false, `it threw: ${gov.threw}`);
+    step("and a role cannot reach past its own table", false, "not reached — the call above threw");
+  } else {
+  step("the governor points only at halls that exist",
+       !!gov.real && gov.proto === null && gov.ctor === null && gov.none === null,
+       `lib → ${JSON.stringify(gov.real)} · __proto__ → ${JSON.stringify(gov.proto)} · ` +
+       `constructor → ${JSON.stringify(gov.ctor)} · no target → ${JSON.stringify(gov.none)}`);
+  step("and a role cannot reach past its own table",
+       gov.overreach === null && gov.protoEscalate === null && gov.protoPoints !== null,
+       `social proposing open_registration → ${JSON.stringify(gov.overreach)} · ` +
+       `class "__proto__" proposing it → ${JSON.stringify(gov.protoEscalate)} · ` +
+       `and pointing at a hall → ${gov.protoPoints ? "allowed, as social" : "refused"}`);
+  }
+
+  /* ── 3. a turn that is no longer the turn writes nothing ─────────
      A provider that ignores abort and takes its time, so the
      continuation lands well after the conversation has changed hands.
      Nothing else about the page is stubbed: the real submit handler,

--- a/tools/check-owner.mjs
+++ b/tools/check-owner.mjs
@@ -1,0 +1,234 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — who owns the keyboard, and whose turn is it?
+ *
+ *     node tools/check-owner.mjs
+ *
+ * One question asked twice. Input and async continuations both act on
+ * the campus, and neither used to check who currently holds it.
+ *
+ *   1. Four global key listeners each knew its own mode and none knew
+ *      the overlay stack. With the application dialog open and focus on
+ *      a <select>, pressing 2, f, n changed the sector and entered
+ *      first-person walk mode behind a dialog that stayed open.
+ *
+ *   2. A finished AI turn wrote its line, gesture, call to action,
+ *      history, speech and focus to the conversation surface without
+ *      asking whether that surface was still the one it started in. It
+ *      never misbehaved, because convoClose() aborts and the abort beat
+ *      the continuation every time — safety resting on an ordering
+ *      nothing enforced. So this installs a provider that IGNORES
+ *      abort, which is the case the ordering does not cover.
+ */
+import { chromium } from "playwright";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { resolve, extname, dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PORT = 8095;
+const MIME = { ".html":"text/html", ".js":"text/javascript", ".mjs":"text/javascript",
+  ".css":"text/css", ".glb":"model/gltf-binary", ".png":"image/png", ".woff2":"font/woff2",
+  ".jpg":"image/jpeg", ".webp":"image/webp", ".svg":"image/svg+xml",
+  ".webmanifest":"application/manifest+json" };
+
+const server = createServer(async (req, res) => {
+  let rel;
+  try { rel = decodeURIComponent(req.url.split("?")[0]); }
+  catch { res.writeHead(400); return res.end(); }
+  if (rel === "/favicon.ico"){ res.writeHead(204); return res.end(); }
+  const path = resolve(ROOT, "." + (rel === "/" ? "/index.html" : rel));
+  if (path !== ROOT && !path.startsWith(ROOT + sep)){ res.writeHead(403); return res.end(); }
+  if (!existsSync(path) || statSync(path).isDirectory()){ res.writeHead(404); return res.end(); }
+  res.writeHead(200, { "content-type": MIME[extname(path)] || "application/octet-stream" });
+  res.end(await readFile(path));
+});
+
+const failures = [];
+const step = (name, ok, detail = "") => {
+  console.log(`${ok ? "  ok  " : " FAIL "} ${name}${detail ? "  — " + detail : ""}`);
+  if (!ok) failures.push(name);
+};
+
+await new Promise(r => server.listen(PORT, r));
+const browser = await chromium.launch({
+  args: ["--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"],
+});
+const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+const page = await ctx.newPage();
+
+/* what the campus looks like from outside, in the terms the bug is in */
+const campus = () => page.evaluate(() => ({
+  /* the real key, checked against LS_SECTOR rather than guessed —
+     the first draft read "pembroke.sector", which is nothing, so that
+     dimension answered null every time and compared equal to itself */
+  sector: localStorage.getItem("pembroke.registrar.sector"),
+  walk:   document.body.classList.contains("walkmode"),
+  night: !document.body.classList.contains("day"),
+  modal:  document.getElementById("jmodal").classList.contains("open"),
+  convo:  document.body.classList.contains("convo-open"),
+}));
+
+try {
+  await page.goto(`http://localhost:${PORT}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  if (!await page.waitForFunction(() => window.__app && window.__journey, null, { timeout: 240_000 })
+        .then(() => true, () => false)) throw new Error("the campus did not ignite");
+
+  /* ── 1. a dialog owns the keyboard while it is open ──────────────
+     Every focusable control in the dialog, not just the first: the
+     original bug needed focus on a <select>, because <select> is the
+     one an "input,textarea" test does not name. */
+  /* Campus Visit done and nothing submitted, so the panel's one call to
+     action is "Apply to Pembroke" — the only dialog with <select> in
+     it, and <select> is the control the bug needed. */
+  await page.evaluate(() => localStorage.setItem("pembroke.registrar.journey", JSON.stringify({
+    onboarding: { campusVisit: { status: "done", steps: {}, completedAt: 1, hidden: false } },
+  })));
+  await page.reload({ waitUntil: "domcontentloaded", timeout: 90_000 });
+  if (!await page.waitForFunction(() => window.__app && window.__journey, null, { timeout: 240_000 })
+        .then(() => true, () => false)) throw new Error("no ignition after seeding the ledger");
+
+  const opened = await page.evaluate(async () => {
+    const btn = [...document.querySelectorAll("#journey button")]
+      .find(b => /apply to pembroke/i.test(b.textContent || ""));
+    if (!btn) return { ok: false, why: "no Apply control — the ledger seed did not take" };
+    btn.click();
+    await new Promise(r => setTimeout(r, 300));
+    return { ok: document.getElementById("jmodal").classList.contains("open"),
+             selects: document.querySelectorAll("#jmodal-body select").length };
+  });
+  step("the application is open, selects and all", opened.ok && opened.selects >= 2,
+       opened.why || `${opened.selects} <select> in the dialog — the control an "input,textarea" test does not name`);
+
+  const before = await campus();
+  const controls = await page.evaluate(() =>
+    document.querySelectorAll("#jmodal-body a[href],#jmodal-body button,#jmodal-body input,#jmodal-body select,#jmodal-body textarea").length);
+  const leaked = [];
+  for (let i = 0; i < controls; i++){
+    await page.evaluate((n) => {
+      const els = [...document.querySelectorAll("#jmodal-body a[href],#jmodal-body button,#jmodal-body input,#jmodal-body select,#jmodal-body textarea")];
+      els[n]?.focus();
+    }, i);
+    for (const k of ["2", "f", "n", "p", "0"]) await page.keyboard.press(k);
+    const now = await campus();
+    for (const key of ["sector", "walk", "night"])
+      if (now[key] !== before[key] && !leaked.includes(key)) leaked.push(key);
+    if (!now.modal) { leaked.push("the dialog closed"); break; }
+  }
+  step("campus shortcuts do nothing while a dialog holds the keyboard",
+       controls > 0 && leaked.length === 0,
+       controls === 0 ? "no controls in the dialog to press keys from"
+         : `${controls} control(s) tried × 5 keys` +
+           (leaked.length ? ` · moved: ${leaked.join(", ")}` : ""));
+
+  /* and the dialog's own key still works */
+  await page.keyboard.press("Escape");
+  const shut = await page.evaluate(() =>
+    !document.getElementById("jmodal").classList.contains("open"));
+  step("but the dialog's own Escape still closes it", shut);
+
+  /* ── 2. a turn that is no longer the turn writes nothing ─────────
+     A provider that ignores abort and takes its time, so the
+     continuation lands well after the conversation has changed hands.
+     Nothing else about the page is stubbed: the real submit handler,
+     the real governor, the real DOM. */
+  /* The cohort arrives progressively, so ask rather than assume — a
+     race between two students needs two students. */
+  const arrived = await page.waitForFunction(
+    () => window.__students.filter(x => x.data?.name && x.g?.visible).length >= 2,
+    null, { timeout: 180_000 }).then(() => true, () => false);
+  step("two people are out on the quad to talk to", arrived);
+
+  const race = await page.evaluate(async () => {
+    const { AIProviders, AI } = window.__ai;
+    AI.cfg.mode = "hosted"; AI.cfg.gateway = "http://example.invalid";
+    AIProviders.hosted = async (s, userText, history, onToken) => {
+      await new Promise(r => setTimeout(r, 2500));   /* the signal is ignored on purpose */
+      onToken?.("A LINE FROM THE FIRST CONVERSATION");
+      return { dialogue: "A LINE FROM THE FIRST CONVERSATION",
+               emotion: "neutral", intent: { type: "none" } };
+    };
+    const named = window.__students.filter(x => x.data?.name && x.g?.visible);
+    if (named.length < 2) return { ok: false, why: `only ${named.length} student(s) on the quad` };
+    const [a, b] = named;
+
+    const talk = async (who) => {
+      window.__talkTo(who.data.name);
+      await new Promise(r => setTimeout(r, 300));
+      const input = document.getElementById("convo-input");
+      if (!input || document.getElementById("convo-say-row").hidden)
+        return "the conversation has no input row — no live provider";
+      input.value = "hello there";
+      document.getElementById("convo-send").click();
+      return null;
+    };
+    const why = await talk(a);
+    if (why) return { ok: false, why };
+
+    await new Promise(r => setTimeout(r, 400));      /* the turn is in flight */
+
+    /* Escape is how a visitor leaves, and it runs the real convoClose —
+       including the abort this provider ignores. The first draft of
+       this clicked #convo-cancel, which only aborts; the conversation
+       stayed open, convoOpen refused to replace it (it returns early
+       while convoView is set), and the check then blamed the page for
+       A's reply landing in A's own conversation. Verify B actually has
+       the surface before believing anything that follows. */
+    document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    await new Promise(r => setTimeout(r, 250));
+    if (document.body.classList.contains("convo-open"))
+      return { ok: false, why: "Escape did not close the first conversation" };
+    window.__talkTo(b.data.name);                     /* B takes the surface */
+    await new Promise(r => setTimeout(r, 300));
+    const holder = window.__ai.gen;
+    const bOpener = document.getElementById("convo-said").textContent;
+    if (!document.body.classList.contains("convo-open"))
+      return { ok: false, why: `${b.data.name}'s conversation never opened` };
+    await new Promise(r => setTimeout(r, 3000));      /* A's continuation lands here */
+
+    return { ok: true, a: a.data.name, b: b.data.name, bOpener, gen: holder(),
+             said: document.getElementById("convo-said").textContent,
+             /* Every DOM sink at once — the line, the gesture caption,
+                the call-to-action label, the spoken bubble over the
+                figure. Naming them one at a time would miss whichever
+                one gets added next. */
+             anywhere: document.body.innerText.includes("A LINE FROM THE FIRST CONVERSATION"),
+             aHist: (a.aiHist || []).length, bHist: (b.aiHist || []).length,
+             stillOpen: document.body.classList.contains("convo-open") };
+  });
+
+  if (!race.ok){
+    step("a finished turn cannot write into the next conversation", false, race.why);
+  } else {
+    const bled = race.said.includes("A LINE FROM THE FIRST CONVERSATION");
+    step("a finished turn cannot write into the next conversation", !bled && race.stillOpen,
+         !race.stillOpen ? `${race.b}'s conversation did not survive the wait — nothing was proved`
+         : bled ? `${race.a}'s reply landed in ${race.b}'s conversation`
+                : `${race.b}'s surface still reads its own opener: ${JSON.stringify(race.bOpener.slice(0, 48))}`);
+    /* Not a history check: aiHist hangs off each student record, so
+       one student's turns cannot land in another's whatever happens,
+       and a check asserting that can only ever pass. The reachable
+       question is whether the words appear ANYWHERE — the gesture, the
+       call to action and the spoken bubble are separate writes to
+       separate places, and all of them are downstream of the same
+       guard. bHist is reported because it is worth seeing, not
+       asserted because it cannot move. */
+    step("nor anywhere else on the campus", !race.anywhere,
+         race.anywhere ? `${race.a}'s words are somewhere in the document`
+           : `nothing of ${race.a}'s turn reached the page · ${race.a} kept ${race.aHist}, ${race.b} holds ${race.bHist}`);
+  }
+} catch (e) {
+  step("ownership check completed", false, e.message.split("\n")[0]);
+} finally {
+  await browser.close();
+  server.close();
+}
+
+if (failures.length){
+  console.log(`\n${failures.length} check(s) failed: ${failures.join(", ")}`);
+  process.exit(1);
+}
+console.log("\nall ownership checks passed.");

--- a/tools/check-worker.mjs
+++ b/tools/check-worker.mjs
@@ -276,6 +276,26 @@ step("every character the Worker voices exists on the campus", missing.length ==
 step("the two halves agree what class each character is", misclassed.length === 0,
      misclassed.join(" | "));
 
+/* Who exists and what they may propose was already checked; how each
+   side DESCRIBES them was not, and that is where the drift actually
+   happened. The Worker names a role per character. The browser built
+   one sentence for everybody — "a ${year} at Pembroke Academy studying
+   ${major}" — which is right for a sophomore and wrong for everyone
+   who teaches, so the Dean was studying Academic Advising and the
+   professor was studying Applied Calculus. Anyone the Worker does not
+   call a student must not be called one here either. */
+const TEACHES = Object.entries(CHARACTERS).filter(([, c]) => c.cls !== "social" && c.cls !== "academic");
+const studied = TEACHES.filter(([id]) => {
+  const name = Object.entries(CHARACTERS).find(([k]) => k === id)[1].name;
+  const rec = page.match(new RegExp(`\\{\\s*name:\\s*"${name.replace(/[.*+?^$(){}|[\]\\]/g, "\\$&")}",\\s*ai:\\s*\\{[\\s\\S]{0,600}?\\}`));
+  return !rec || !/\brole:\s*"/.test(rec[0]);
+}).map(([id]) => id);
+step("nobody the Worker calls faculty is called a student on the campus",
+     TEACHES.length > 0 && studied.length === 0,
+     TEACHES.length === 0 ? "the Worker lists no faculty — this check proved nothing"
+       : studied.length ? `${studied.join(", ")} — no role: on the campus record, so the student sentence is used`
+       : `${TEACHES.map(([id]) => id).join(", ")} each carry their own role`);
+
 const policy = page.match(/const AI_POLICY = \{([\s\S]*?)\n\};/);
 const clientIntents = new Set([...(policy?.[1] || "").matchAll(/"([a-z_]+)"/g)].map(m => m[1]));
 const docIntents = new Set([...WORKER_SRC


### PR DESCRIPTION
Closes #106. Closes #77. Closes #80.

Three issues, one theme running through all of them: **something was fixed in one place and not in its twin.**

## #106 — nothing acts on the campus without owning it

One question asked twice. Input and async continuations both act on the campus, and neither checked who currently holds it.

**Part 1 — shortcuts mutate the campus behind an open dialog.** With the application dialog open, walking focus across all eleven of its controls and pressing `2 f n p 0` at each:

```
against main   →  moved: sector, walk, night
now            →  nothing moved
```

The campus changed quad and entered first-person walk mode behind a dialog that stayed open. The editable-target test covered `input,textarea`; a `<select>` is neither, and no handler asked whether anything was open.

**Worth stating because it's the more useful lesson: the accessibility work in #113 made this *look* solved.** The background is genuinely `inert` now, so a keyboard cannot *reach* the campus behind a dialog. `inert` does nothing about a listener bound to `window`, which receives the key wherever it was pressed. A surface that looks sealed and isn't is worse than one that looks open.

Two deliberate decisions in the predicate: an **interior is not an owner** (it's a campus view, and switching sector from inside a hall closes it on the way), and **Escape belongs to the innermost thing that is open** — the first draft let Escape through while a dialog was up, which would have closed the hall *behind* it, the exact bug the line above was fixing.

**Part 2 — a finished AI turn writes to whatever conversation is open.** The issue filed this as *"confirmed race in code; timing-dependent reproduction"*, and that was right: it never misbehaved because `convoClose()` aborts and the abort beat the continuation every time — safety resting on an ordering nothing enforced. Every turn now takes a generation stamp before its first `await` and checks it after every one, the token callback included. The generation catches a close-and-reopen of the **same** student, which `convoView === s` alone would wave through.

```
guards removed  →  "Dean Aldergate's reply landed in Prof. Merion's conversation"
now             →  "nothing of Prof. Merion's turn reached the page"
```

## #77 — the governor answered for the prototype

`SECTORS["__proto__"]` is truthy and its `.hall` is `undefined`, so that target rendered *"(points toward undefined)"*. `Object.hasOwn` now — which is exactly what the sector restore was given in v139, while this one, already filed, was left. Two lookups into the same object disagreeing about whether `__proto__` is a hall.

The policy lookup beside it had a **worse** version of the same bug that nobody had noticed. `AI_POLICY["__proto__"]` resolves to `Object.prototype`, which is truthy — so the `|| AI_POLICY.social` fallback never fired and `.includes` threw:

```
TypeError: (AI_POLICY[cls] || AI_POLICY.social).includes is not a function
```

`cls` comes from campus data rather than model output, so that half is defence in depth; the rule is easier to keep with no exceptions.

One correction to my own check while writing it: I first asserted an unknown class must be refused outright. That's wrong — falling back to `AI_POLICY.social` is by design and is the *safe* direction, social being the least-privileged table. The question isn't whether `__proto__` may point at a hall (any stranger may) but whether it inherits anything more, so the check asserts it cannot propose `open_registration`.

## #80 — the faculty were described as students

```
before   "You are Dean Aldergate, a dean of students at Pembroke Academy studying Academic Advising"
after    "You are Dean Aldergate, the Dean of Students and academic advisor at Pembroke Academy"
```

The hosted Worker never had this, because its registry carries a role per character. The two faculty now carry one too, and the student sentence stays the fallback for everyone else.

**That's the second time the Worker's copy of a prompt was correct and the browser's lagged** — PE-16's *"Authorized"* wording was the first, found by reading the same function for an unrelated reason. `check-worker.mjs` asserted the two halves agree on *who exists* and *what they may propose*, and said nothing about how either side **describes** them, which is where both of these lived. It now asserts nobody the Worker calls faculty is called a student on the campus — red against the previous commit for `dean-aldergate` and `prof-merion`. Evidence for scoping PE-29 in #107.

## The gate

`tools/check-owner.mjs`, eight checks, its own CI job — the seventh in the suite. Its conversation half installs a provider that **ignores abort**, which is the case the ordering doesn't cover and the one a real provider cannot be asked to perform on demand. `AIProviders` joins the debug hook so the probe can install it.

## Four bugs in my own probes, caught before they became green lies

- It clicked `#convo-cancel`, which only aborts. The conversation never closed, `convoOpen` refused to replace it, and the check blamed the page for a reply landing in its own conversation.
- It read `localStorage["pembroke.sector"]`. The real key is `pembroke.registrar.sector`, so that dimension answered `null` every run and compared equal to itself — a silently vacuous third of the assertion.
- Its history check could not fail. `aiHist` hangs off each student record, so one student's turns cannot land in another's whatever happens. Replaced with a document-wide search covering the line, the gesture, the CTA label and the spoken bubble at once.
- The governor block had no `try` of its own, so the throw it exists to catch took the whole probe down and reported as *"ownership check completed"*, which names nothing.

## Verification

Local, each suite on its own machine time: `worker` ✅ · `css` ✅ · `owner` ✅ · `a11y` ✅ · `ledger` ✅ · `cache-version` guard ✅ · full smoke drive ✅ 62 checks (on v143; re-running for v144).