### PR TITLE
v145: the first twenty seconds are the campus

### DIFF
--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -408,3 +408,49 @@ jobs:
 
       - name: Does anything act on the campus without owning it?
         run: node tools/check-owner.mjs
+
+  # ── the first twenty seconds ────────────────────────────────────────
+  # A juror gives a site one to three minutes, and every other job here
+  # is blind to the first of them: Playwright sets navigator.webdriver,
+  # the arrival reads that as "somebody is measuring, skip the
+  # theatrics" — which is the right call and makes the theatrics
+  # untestable. This job lies about webdriver on purpose. It is the only
+  # way to test a cinematic that only first-time visitors ever see.
+  #
+  # It asserts ORDER and POSE, never wall-clock: on a runner with no GPU
+  # the descent runs at one to three frames a second and every duration
+  # stretches, while the sequence does not.
+  opening:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Cache the browser
+        id: browser
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PW_VERSION }}
+
+      - name: Install Playwright
+        timeout-minutes: 6
+        run: npm install --no-save --no-audit --no-fund playwright@${{ env.PW_VERSION }}
+
+      - name: Fetch the browser
+        if: steps.browser.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
+
+      - name: System libraries for the cached browser
+        if: steps.browser.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
+
+      - name: Where does a first visit actually end up?
+        run: node tools/check-opening.mjs

--- a/index.html
+++ b/index.html
@@ -937,6 +937,34 @@ body.walkmode #topbar{visibility:hidden;}
    when somebody starts exploring; walking IS that, so it bows out
    here too rather than fighting the thumb pad for the same pixels. */
 .walkmode #arr-cta{display:none;}
+
+/* ── the opening beat ─────────────────────────────────────────────
+   A juror gives a site one to three minutes. Measured on a Pixel 5,
+   the old arrival ended at 26.9s in an aerial view — at night, behind
+   four label chips, a legend, three lines of intro copy and a progress
+   ledger, with the campus itself in the bottom third of a document.
+   That is the frame this product was being judged on.
+
+   So for the length of the flight and a beat after it lands: the
+   campus, and nothing else. Everything here is chrome that exists to
+   introduce the world, and none of it introduces the world as well as
+   the world does. It fades back in afterwards — the transition is on
+   the way IN, which is why it is two seconds and not four hundred
+   milliseconds. First input of any kind ends this early; nobody is
+   trapped in a cinematic. */
+body.opening #topbar{visibility:hidden;}
+body.opening #campus-wing-intro, body.opening #campus-legend,
+body.opening #campus-hints, body.opening #quest, body.opening #minimap,
+body.opening #daynight, body.opening #walkbtn, body.opening #nearbybtn,
+body.opening #journey, body.opening #toasts, body.opening .b-label,
+body.opening #arr-cta{
+  opacity:0 !important; pointer-events:none !important;
+}
+#campus-wing-intro, #campus-legend, #campus-hints, #quest, #minimap,
+#daynight, #walkbtn, #nearbybtn, #journey, #toasts, .b-label{
+  transition:opacity 2s ease;
+}
+#arr-skip{transition:opacity .3s ease;}
 .convo-card{position:absolute;left:0;right:0;bottom:0;
   padding:1.1rem 1.4rem 1.3rem;
   background:linear-gradient(0deg, rgba(6,8,14,.94) 55%, rgba(6,8,14,.72) 80%, transparent);
@@ -3592,7 +3620,7 @@ import { OutputPass } from "three/addons/postprocessing/OutputPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v144";
+const BUILD = "pembroke-v145";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */
@@ -16768,12 +16796,17 @@ if (Journey.get().onboarding.campusVisit.status === "active"){ orientOn = true; 
     else setTimeout(tick, 200);
   };
   const finishSweep = () => {
-    controls.enabled = true;
+    /* not in walk mode: enterWalk turned the orbit controls off on
+       purpose, and handing them back would fight the walker */
+    controls.enabled = !walker.on;
     const skip = document.getElementById("arr-skip");
     if (skip) skip.remove();
-    /* the entrance ends where the journey begins */
+    /* the entrance ends where the journey begins — except when the
+       entrance has already put them ON the quad, where the campus is
+       the pitch and this button would only be a button. The journey
+       panel still offers Start Campus Visit whenever they surface. */
     const cv = Journey.get().onboarding.campusVisit;
-    if (Journey.status() === "visitor" && cv.status === "new"){
+    if (!walker.on && Journey.status() === "visitor" && cv.status === "new"){
       const b = document.createElement("button");
       b.id = "arr-cta"; b.className = "jcta";
       b.textContent = "Begin — your Campus Visit";
@@ -16790,21 +16823,64 @@ if (Journey.get().onboarding.campusVisit.status === "active"){ orientOn = true; 
     el.classList.add("gone");
     setTimeout(() => el.remove(), 900);
     if (plain || !firstVisitEver || walker.on){ finishSweep(); return; }
-    /* the descent: high above the North Quad, the cathedral below,
-       sweeping down and around to the standard aerial framing */
+
+    /* The descent used to end at AERIAL — a view of the campus beside
+       a checklist. It ends ON the campus now, because the single most
+       award-caliber thing here is standing on the quad at eye height
+       with the cathedral on axis, and it used to be three minutes and
+       five decisions away: aerial, journey panel, Start Campus Visit,
+       orientation, find the 🎮 chip.
+
+       Nothing below is new scenery. The walk-in point, its heading and
+       the golden preset all already existed; enterWalk() has always
+       started at (500, 802) facing h=0, and h=0 is straight down the
+       axis the fountain and the cathedral already share. This only
+       changes where the camera stops. */
     controls.enabled = false;
+    document.body.classList.add("opening");
+    /* Their sky is "live" by default — the hour they are actually
+       standing in — which is a good default and the wrong postcard:
+       a first visit at ten at night opens on a dark quad. Golden for
+       the opening, their own preference back the moment it ends. */
+    engineSetMode("golden");
     camera.position.set(120, 1500, -2300);
     controls.target.set(0, 60, -420);
-    flyTo(new THREE.Vector3(0, 30, 0), aerialPos(), finishSweep, 5200);
+    /* land exactly where walk mode will put the camera, so the
+       handover has no cut in it: eye height at the walk-in point,
+       looking north at the cathedral */
+    const EYE = walker.eye;
+    flyTo(new THREE.Vector3(W(500), EYE, W(-300)),
+          new THREE.Vector3(W(500), EYE, W(802)), () => land(true), 5200);
+
+    let landed = false;
+    /* One way out, whether it arrives as a click on skip, a keypress,
+       a touch or a scroll. `soft` is the flight finishing on its own,
+       which earns the beat; anything else is somebody asking for the
+       controls and gets them now. */
+    function land(soft){
+      if (landed) return;
+      landed = true;
+      for (const [t, f] of takeovers) window.removeEventListener(t, f);
+      window.__flightAbort && window.__flightAbort();
+      enterWalk();
+      const reveal = () => {
+        document.body.classList.remove("opening");
+        applyMode();                    /* the sky they actually chose */
+        finishSweep();
+      };
+      if (soft) setTimeout(reveal, 2400); else reveal();
+    }
+    const takeovers = [];
+    for (const t of ["keydown", "pointerdown", "wheel", "touchstart"]){
+      const f = () => land(false);
+      takeovers.push([t, f]);
+      window.addEventListener(t, f, { once: true, passive: true });
+    }
     const skip = document.createElement("button");
     skip.id = "arr-skip"; skip.textContent = "skip";
-    skip.onclick = () => {
-      controls.target.set(0, 30, 0);
-      aerialHome();
-      window.__flightAbort && window.__flightAbort();
-      finishSweep();
-    };
+    skip.onclick = () => land(false);
     document.body.appendChild(skip);
+    window.__opening = { land };   /* test/debug hook */
   };
   window.__flightAbort = () => { if (typeof flight !== "undefined") flight = null; };
   window.__arrival = { arrive, tick };   /* test/debug hook */

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v144";
+const VERSION = "pembroke-v145";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/check-opening.mjs
+++ b/tools/check-opening.mjs
@@ -1,0 +1,181 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — the first twenty seconds.
+ *
+ *     node tools/check-opening.mjs
+ *
+ * A juror gives a site one to three minutes, and every other probe in
+ * this repository is blind to what happens in the first of them —
+ * because Playwright sets navigator.webdriver, the arrival reads that
+ * as "no theatrics", and the opening never runs. So this one lies
+ * about webdriver on purpose. It is the only way to test a cinematic
+ * that only first-time visitors ever see.
+ *
+ * What it asserts is ORDER and POSE, never wall-clock. On a machine
+ * with no GPU the descent runs at one to three frames a second and
+ * every duration stretches; the sequence does not.
+ */
+import { chromium, devices } from "playwright";
+import { createServer } from "node:http";
+import { readFile } from "node:fs/promises";
+import { existsSync, statSync } from "node:fs";
+import { resolve, extname, dirname, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PORT = 8092;
+const MIME = { ".html":"text/html", ".js":"text/javascript", ".mjs":"text/javascript",
+  ".css":"text/css", ".glb":"model/gltf-binary", ".png":"image/png", ".woff2":"font/woff2",
+  ".jpg":"image/jpeg", ".webp":"image/webp", ".svg":"image/svg+xml",
+  ".webmanifest":"application/manifest+json" };
+
+const server = createServer(async (req, res) => {
+  let rel;
+  try { rel = decodeURIComponent(req.url.split("?")[0]); }
+  catch { res.writeHead(400); return res.end(); }
+  if (rel === "/favicon.ico"){ res.writeHead(204); return res.end(); }
+  const path = resolve(ROOT, "." + (rel === "/" ? "/index.html" : rel));
+  if (path !== ROOT && !path.startsWith(ROOT + sep)){ res.writeHead(403); return res.end(); }
+  if (!existsSync(path) || statSync(path).isDirectory()){ res.writeHead(404); return res.end(); }
+  res.writeHead(200, { "content-type": MIME[extname(path)] || "application/octet-stream" });
+  res.end(await readFile(path));
+});
+
+const failures = [];
+const step = (name, ok, detail = "") => {
+  console.log(`${ok ? "  ok  " : " FAIL "} ${name}${detail ? "  — " + detail : ""}`);
+  if (!ok) failures.push(name);
+};
+
+await new Promise(r => server.listen(PORT, r));
+const browser = await chromium.launch({
+  args: ["--enable-unsafe-swiftshader", "--disable-dev-shm-usage", "--no-sandbox"],
+});
+
+/* The timeline is recorded INSIDE the page, so nothing here depends on
+   how long a screenshot or a round trip takes on a software rasterizer. */
+const RECORD = () => {
+  window.__tl = [];
+  const t0 = performance.now();
+  const iv = setInterval(() => {
+    const q = document.getElementById("quest");
+    window.__tl.push({
+      t: Math.round(performance.now() - t0),
+      arrival: !!document.getElementById("arrival"),
+      opening: document.body.classList.contains("opening"),
+      walk: document.body.classList.contains("walkmode"),
+      day: document.body.classList.contains("day"),
+      chrome: q ? +getComputedStyle(q).opacity : null,
+      camY: window.__app ? Math.round(window.__app.camera.position.y) : null,
+      camZ: window.__app ? Math.round(window.__app.camera.position.z) : null,
+      yaw:  window.__app ? +window.__app.camera.rotation.y.toFixed(3) : null,
+    });
+  }, 200);
+  setTimeout(() => clearInterval(iv), 120_000);
+};
+
+const visit = async (opts = {}) => {
+  const ctx = await browser.newContext({ ...devices["Pixel 5"] });
+  const page = await ctx.newPage();
+  /* the arrival treats webdriver as "somebody is measuring, skip the
+     theatrics", which is right — and makes the theatrics untestable */
+  await page.addInitScript(() => Object.defineProperty(navigator, "webdriver", { get: () => false }));
+  if (opts.before) await page.addInitScript(opts.before);
+  await page.addInitScript(RECORD);
+  await page.goto(`http://localhost:${PORT}/`, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  return { ctx, page };
+};
+/* Wait on the PAGE's own recording, not on a duration. The budget is
+   generous because a software rasterizer runs the descent at one to
+   three frames a second; PEMBROKE_WAIT_MS shortens it so a run that is
+   MEANT to fail — checking this probe against a build without the
+   opening — fails in a minute instead of holding every wait in turn. */
+const WAIT = +(process.env.PEMBROKE_WAIT_MS || 180_000);
+const until = (page, pred, ms = WAIT) =>
+  page.waitForFunction(pred, null, { timeout: ms }).then(() => true, () => false);
+
+try {
+  /* ── 1. a first visit ends standing on the quad ─────────────────── */
+  const first = await visit();
+  const landed = await until(first.page, () => document.body.classList.contains("walkmode"));
+  step("a first visit ends on the quad, not above it", landed,
+       landed ? "body.walkmode" : "never entered walk mode — the arrival still lands in the aerial");
+
+  const settled = await until(first.page, () =>
+    !document.body.classList.contains("opening") && window.__app?.camera.position.y < 60);
+  const tl = await first.page.evaluate(() => window.__tl);
+  const at = (pred) => tl.findIndex(pred);
+  const iOpen = at(r => r.opening), iDark = at(r => r.chrome === 0),
+        iWalk = at(r => r.walk),   iBack = at(r => r.opening === false && r.walk);
+
+  step("the chrome is gone before the campus is",
+       iOpen >= 0 && iDark >= 0 && iDark < iWalk,
+       iOpen < 0 ? "body.opening never applied"
+         : `opening at ${tl[iOpen].t}ms · chrome dark at ${tl[iDark]?.t}ms · standing at ${tl[iWalk]?.t}ms`);
+
+  /* An absent opening makes this slice empty and .every vacuously
+     true, so the reason has to be reported separately from the verdict
+     — the first draft printed "daylight held" while failing. */
+  const golden = iOpen >= 0 && iWalk > iOpen && tl.slice(iOpen, iWalk + 1).every(r => r.day);
+  const dark = iOpen >= 0 ? tl.slice(iOpen, iWalk + 1).filter(r => !r.day).length : null;
+  step("and the light is golden for the whole descent", golden,
+       iOpen < 0 ? "there was no descent to light — body.opening never applied"
+       : iWalk <= iOpen ? "it never reached the ground"
+       : dark ? `${dark} frame(s) went dark mid-descent — the opening is showing their clock, not the postcard`
+       : "daylight held from the first frame of the flight to the ground");
+
+  const pose = settled ? tl[tl.length - 1] : null;
+  step("it lands at eye height with the cathedral on axis",
+       !!pose && pose.camY < 60 && Math.abs(pose.yaw) < 0.05,
+       pose ? `camera y=${pose.camY} z=${pose.camZ} yaw=${pose.yaw} — yaw 0 looks down −Z, which is the cathedral`
+            : "the camera never settled");
+
+  step("and the chrome comes back afterwards", iBack > iWalk,
+       iBack > iWalk ? `revealed at ${tl[iBack].t}ms` : "the interface never returned");
+
+  const sky = await first.page.evaluate(() => ({
+    mode: localStorage.getItem("pembroke.registrar.mode"),
+    day: document.body.classList.contains("day"),
+  }));
+  step("the sky handed back is the visitor's, not the postcard's",
+       sky.mode === null,
+       `stored mode ${JSON.stringify(sky.mode)} — the opening must not write a preference the visitor never chose`);
+  await first.ctx.close();
+
+  /* ── 2. nobody is trapped in it ─────────────────────────────────── */
+  const eager = await visit();
+  await until(eager.page, () => document.body.classList.contains("opening"));
+  await eager.page.keyboard.press("Space");
+  const tookOver = await until(eager.page, () =>
+    document.body.classList.contains("walkmode") && !document.body.classList.contains("opening"));
+  step("one keypress during the flight takes the controls immediately", tookOver,
+       tookOver ? "landed and revealed without waiting out the beat"
+                : "the flight held on through a keypress — that is a trapped cinematic");
+  await eager.ctx.close();
+
+  /* ── 3. a returning visitor is not shown the front door twice ──── */
+  const back = await visit({ before: () => {
+    localStorage.setItem("pembroke.registrar.journey", JSON.stringify({
+      onboarding: { campusVisit: { status: "done", steps: {}, completedAt: 1, hidden: false } } }));
+  } });
+  const ready = await until(back.page, () => window.__app && !document.getElementById("arrival"));
+  const returning = await back.page.evaluate(() => ({
+    opening: document.body.classList.contains("opening"),
+    walk: document.body.classList.contains("walkmode"),
+  }));
+  step("a returning visitor gets the campus they left, not the opening",
+       ready && !returning.opening && !returning.walk,
+       `opening=${returning.opening} walk=${returning.walk}`);
+  await back.ctx.close();
+} catch (e) {
+  step("opening check completed", false, e.message.split("\n")[0]);
+} finally {
+  await browser.close();
+  server.close();
+}
+
+if (failures.length){
+  console.log(`\n${failures.length} check(s) failed: ${failures.join(", ")}`);
+  process.exit(1);
+}
+console.log("\nall opening checks passed.");

--- a/tools/check-opening.mjs
+++ b/tools/check-opening.mjs
@@ -101,17 +101,31 @@ try {
   step("a first visit ends on the quad, not above it", landed,
        landed ? "body.walkmode" : "never entered walk mode — the arrival still lands in the aerial");
 
+  /* Wait for the RECORDER to have seen the reveal, not for the page to
+     be in that state. The first draft waited on the page and then read
+     the log, which is a race the log loses: the reveal had happened and
+     the next 200ms sample had not been written, so the check reported
+     "the interface never returned" about an interface that had. */
   const settled = await until(first.page, () =>
-    !document.body.classList.contains("opening") && window.__app?.camera.position.y < 60);
+    window.__tl?.some(r => !r.opening && r.walk && r.camY !== null && r.camY < 60));
   const tl = await first.page.evaluate(() => window.__tl);
   const at = (pred) => tl.findIndex(pred);
   const iOpen = at(r => r.opening), iDark = at(r => r.chrome === 0),
         iWalk = at(r => r.walk),   iBack = at(r => r.opening === false && r.walk);
 
-  step("the chrome is gone before the campus is",
-       iOpen >= 0 && iDark >= 0 && iDark < iWalk,
+  /* iDark <= iWalk, not <. These are two events sampled every 200ms,
+     and on a fast enough machine the fade finishing and the walker
+     landing fall inside one sample — which is indistinguishable from
+     "at the same moment" and is not a fault. Demanding a strictly
+     earlier sample asserts something about the sampler rather than
+     about the page, and it went red on a runner QUICKER than the one
+     it was written on. */
+  step("the chrome is gone by the time the campus is",
+       iOpen >= 0 && iDark >= 0 && iWalk >= 0 && iDark <= iWalk,
        iOpen < 0 ? "body.opening never applied"
-         : `opening at ${tl[iOpen].t}ms · chrome dark at ${tl[iDark]?.t}ms · standing at ${tl[iWalk]?.t}ms`);
+         : iDark < 0 ? "the interface never faded out"
+         : iWalk < 0 ? "it never reached the ground"
+         : `opening at ${tl[iOpen].t}ms · chrome dark at ${tl[iDark].t}ms · standing at ${tl[iWalk].t}ms`);
 
   /* An absent opening makes this slice empty and .every vacuously
      true, so the reason has to be reported separately from the verdict
@@ -124,14 +138,15 @@ try {
        : dark ? `${dark} frame(s) went dark mid-descent — the opening is showing their clock, not the postcard`
        : "daylight held from the first frame of the flight to the ground");
 
-  const pose = settled ? tl[tl.length - 1] : null;
+  const pose = settled ? tl.filter(r => r.walk && !r.opening && r.camY !== null).pop() : null;
   step("it lands at eye height with the cathedral on axis",
        !!pose && pose.camY < 60 && Math.abs(pose.yaw) < 0.05,
        pose ? `camera y=${pose.camY} z=${pose.camZ} yaw=${pose.yaw} — yaw 0 looks down −Z, which is the cathedral`
             : "the camera never settled");
 
-  step("and the chrome comes back afterwards", iBack > iWalk,
-       iBack > iWalk ? `revealed at ${tl[iBack].t}ms` : "the interface never returned");
+  step("and the chrome comes back afterwards", iBack >= 0 && iBack >= iWalk,
+       iBack < 0 ? "the interface never returned"
+                 : `revealed at ${tl[iBack].t}ms, ${tl[iBack].t - tl[iWalk].t}ms after landing`);
 
   const sky = await first.page.evaluate(() => ({
     mode: localStorage.getItem("pembroke.registrar.mode"),


### PR DESCRIPTION
Closes #88. Refs #86 — the first of the award track.

## What a juror was actually seeing

Measured on a Pixel 5 before touching anything:

| mark | ms from navigation |
|---|---|
| arrival door opens | 15 793 |
| flight ends, *"Begin — your Campus Visit"* appears | **26 851** |

And at 30 seconds the frame was: an aerial view at `camY 1035`, at the visitor's own hour — which at ten at night is a dark quad — behind four stacked label chips, a legend, a minimap, three lines of intro copy, a masthead and a progress ledger, with the campus itself in the bottom third of a scrolling document.

Jurors give a site one to three minutes. The best thing this campus does was three minutes and five decisions further on: aerial → journey panel → *Start Campus Visit* → orientation → find the 🎮 chip → walk.

## The shot was already there

This is the part worth keeping. `enterWalk()` has always started at `(500, 802)` with `h = 0` — and `h = 0` is straight down the axis the fountain and the cathedral already share. The golden preset already existed. **No new scenery was authored.** Nobody was ever taken to it.

```
before   camY 1035 · aerial · their clock · every overlay up
after    camY 34 · z 302 · yaw 0 — eye height, cathedral on axis
```

`yaw 0` looks down −Z, which is the cathedral. That's provable from the transform rather than judged from a screenshot.

## Three decisions inside it

**Golden for the descent, their own sky after.** `live` — the hour they're actually standing in — is a good default and the wrong postcard. The opening forces golden **through the engine and never through `localStorage`**: it must not write a preference the visitor didn't choose, and the probe asserts the stored mode is still `null` afterwards.

**No chrome at all until it lands.** Every overlay `body.opening` hides exists to introduce the world, and none of them does it as well as the world does. It fades back over two seconds after a beat on the ground.

**Nobody is trapped.** Any keydown, pointerdown, wheel or touchstart lands immediately and skips the hold. `finishSweep` also no longer hands the orbit controls back while the walker owns them.

Since walk mode has been fullscreen since #67, landing *in* it doesn't only move the camera — it changes which layout the visitor arrives into. That turned out to be the larger half of the win.

## The eighth job, and why it has to exist

`tools/check-opening.mjs`, eight checks. **Every other probe in this repository is structurally blind here**: Playwright sets `navigator.webdriver`, the arrival correctly reads that as *"somebody is measuring, skip the theatrics"*, and so the entire first minute has never been executed by any test. This one lies about `webdriver` on purpose. It is the only way to test a cinematic only first-time visitors ever see.

**Six of its eight checks are red against the previous commit:**

```
 FAIL  a first visit ends on the quad, not above it — never entered walk mode
 FAIL  the chrome is gone before the campus is — body.opening never applied
 FAIL  and the light is golden for the whole descent — there was no descent to light
 FAIL  it lands at eye height with the cathedral on axis — the camera never settled
 FAIL  and the chrome comes back afterwards — the interface never returned
 FAIL  one keypress during the flight takes the controls immediately
```

It asserts **order and pose, never wall-clock**. A runner with no GPU takes the descent at one to three frames a second and every duration stretches; the sequence does not. `PEMBROKE_WAIT_MS` shortens the budget so a deliberately-negative baseline fails in a minute instead of holding every wait in turn.

## One more lying failure message

Third instance of this pattern today, caught in my own probe: an absent opening makes the golden-hour slice empty and `.every` vacuously true, so it printed *"daylight held from the first frame"* **while failing**. The reason is computed separately from the verdict now.

## Verification

Local: `worker` ✅ · `css` ✅ · `opening` ✅ 8 checks · `owner` ✅ · `cache-version` guard ✅, with `ledger`, `a11y` and the full smoke drive running.

## What's left in #86

**#87** (audio — not one audio file in 121 MB), **#89** (visual identity), **#90** (motion design). #87 is the natural next one: highest impact per hour on the 40%-weighted Design score, every site in the winners list has it, and #88's own text says it pairs with the bell on arrival — which now has somewhere to land.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_