### PR TITLE
v148: the walk button was under the bell, on every phone

### DIFF
--- a/index.html
+++ b/index.html
@@ -722,8 +722,8 @@ body.day #daynight{background:linear-gradient(160deg, rgba(255,252,240,.92), rgb
 .nb-where{display:block;font-size:10.5px;color:var(--brass-dim);}
 .nb-empty{padding:.4rem .5rem;font-size:11px;color:#94a3b8;}
 @media (max-width:640px){
-  #soundbtn{top:3.9rem;right:1rem;width:40px;height:40px;font-size:16px;}
-  #nearbybtn{top:6.6rem;right:1rem;width:40px;height:40px;font-size:16px;}
+  /* the rail itself is defined once, in the 1023 block below — this
+     one only has business with the panel it opens */
   .nearby{left:1rem;right:1rem;width:auto;top:7rem;}
 }
 .walkmode #walkbtn{border-color:#38bdf8;background:linear-gradient(160deg, rgba(24,60,90,.95), rgba(10,30,50,.95));}
@@ -1142,9 +1142,26 @@ body.panel-open #toasts{bottom:5.5rem;}
      it. The rail is the thing that has to be reachable, so the moon
      moves and the controls stay. */
   .moon{width:54px;height:54px;top:5%;right:26%;}
-  #daynight{top:1rem;right:1rem;width:40px;height:40px;font-size:17px;}
-  #walkbtn{top:3.9rem;right:1rem;width:40px;height:40px;font-size:16px;}
-  #minimap{top:6.8rem;right:1rem;width:96px;height:96px;}
+  /* ── the rail, on a phone ───────────────────────────────────────
+     One column, one pitch, in one place. It was written in two blocks
+     at two breakpoints and they disagreed: the walk button and the
+     sound button were both at top:3.9rem right:1rem — the same
+     coordinates — and since #soundbtn comes later in the markup it
+     painted straight over the walk control. The minimap sat on the
+     people button the same way.
+
+     The cost was not cosmetic. There is no F key on a phone, so the
+     button IS walk mode there, and tapping it hit the bell instead:
+     the best thing this campus does was unreachable on the device
+     most visitors arrive on.
+
+     40px buttons at a 2.9rem pitch, the plan last. Any future control
+     goes on the end of this list and nowhere else. */
+  #daynight {top:1rem;    right:1rem;width:40px;height:40px;font-size:17px;}
+  #soundbtn {top:3.9rem;  right:1rem;width:40px;height:40px;font-size:16px;}
+  #nearbybtn{top:6.8rem;  right:1rem;width:40px;height:40px;font-size:16px;}
+  #walkbtn  {top:9.7rem;  right:1rem;width:40px;height:40px;font-size:16px;}
+  #minimap  {top:12.6rem; right:1rem;width:96px;height:96px;}
   #quest{left:1rem;top:auto;bottom:5.2rem;max-width:250px;}
 }
 @media (max-width:639px){
@@ -3763,7 +3780,7 @@ import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v147";
+const BUILD = "pembroke-v148";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v147";
+const VERSION = "pembroke-v148";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/check-a11y.mjs
+++ b/tools/check-a11y.mjs
@@ -262,9 +262,59 @@ try {
   step("without taking its keyboard legend away", touch.keys !== "none",
        `#hint-keys display ${touch.keys} — a device with both needs both`);
 
+  /* ── nothing on the rail sits on anything else ──────────────────
+     Three separate times this repository has put two controls at the
+     same coordinates and shipped it, because CSS fails silently: a
+     rule at one breakpoint and a rule at another disagree, the later
+     one paints over the earlier, and everything still "works" — the
+     covered control is simply unreachable. The worst of them put the
+     sound button exactly on top of the walk button on a phone, where
+     there is no F key, so the one way into walk mode could not be
+     tapped at all.
+
+     No assertion about a single element would have caught any of
+     them. This asks the only question that would: do any two of these
+     overlap? */
+  const RAIL = () => {
+    const ids = ["daynight", "soundbtn", "nearbybtn", "walkbtn", "minimap", "quest"];
+    const seen = ids.map(id => {
+      const el = document.getElementById(id);
+      if (!el) return null;
+      const cs = getComputedStyle(el);
+      if (cs.display === "none" || cs.visibility === "hidden" || +cs.opacity < 0.05) return null;
+      const r = el.getBoundingClientRect();
+      return r.width && r.height ? { id, x: r.left, y: r.top, r: r.right, b: r.bottom } : null;
+    }).filter(Boolean);
+    const clashes = [];
+    for (let i = 0; i < seen.length; i++)
+      for (let j = i + 1; j < seen.length; j++){
+        const a = seen[i], b = seen[j];
+        if (a.x < b.r && b.x < a.r && a.y < b.b && b.y < a.b)
+          clashes.push(`${a.id} over ${b.id}`);
+      }
+    return { count: seen.length, clashes };
+  };
+  const railStep = (where, r) =>
+    step(`no two controls on the rail are in the same place — ${where}`,
+         r.count >= 4 && r.clashes.length === 0,
+         r.count < 4 ? `only ${r.count} control(s) visible to compare`
+           : r.clashes.length ? r.clashes.join(", ")
+           : `${r.count} controls, none overlapping`);
+  railStep("desktop", await page.evaluate(RAIL));
+
   /* and a phone, which reports the coarse pointer outright, is covered
      by the media query rather than by the class */
   const phone = await open(devices["Pixel 5"]);
+
+  /* Asked FIRST, before the touchpad check puts the page into walk
+     mode, because the rail a visitor arrives to is the one that has to
+     be usable — and asked here at all because on the desktop alone it
+     passed against a build where the sound button sat exactly on top
+     of the walk button. The rail is only redefined below 1023px, so
+     the fault lived entirely inside a block the desktop never reads.
+     A check at one viewport says nothing about the others. */
+  railStep("Pixel 5", await phone.page.evaluate(RAIL));
+
   const padPhone = await phone.page.evaluate(() => {
     document.body.classList.add("walkmode");
     return { coarse: matchMedia("(any-pointer: coarse)").matches,


### PR DESCRIPTION
Reported from the live site, with a screenshot: *"how do I enter walk mode?"* The answer was that you couldn't.

```
<=1023px   #daynight 1rem     #walkbtn 3.9rem     #minimap 6.8rem
<=640px    #soundbtn 3.9rem   #nearbybtn 6.6rem
```

The walk button and the sound button were at the same `top` and the same `right`. `#soundbtn` comes later in the markup, so it painted over the walk control; the minimap did the same to the people button.

**There is no `F` key on a phone, so that button *is* walk mode there** — the best thing this campus does was unreachable on the device most visitors arrive on.

Mine, from v147: I moved four controls into a vertical rail and updated the phone positions for two of them, leaving walk and the plan at coordinates the old L-shaped layout had chosen. The rail is defined **once** now, in one block, at one pitch, and any future control goes on the end of that list and nowhere else.

## The guard matters more than the fix

This is the **fourth** rule this session written somewhere it could not take effect:

| rule | why it never fired |
|---|---|
| `#stage.walking` | against a class that never occurs — the class is `body.walkmode` |
| `max-width` caps | applied at every width instead of the one that needed it |
| `.moon` | set above the breakpoint that owns its position |
| the rail | split across two disagreeing blocks |

CSS fails silently. A rule that never fires looks exactly like a rule that works, and **a control that is covered still reports as visible, focusable and clickable** — which is why nine CI jobs and a dozen probes never saw this, and a glance at a phone did.

No assertion about any single element would have caught any of them. The new check asks the only question that would — *do any two of these overlap* — and against the deployed build it answers:

```
FAIL  no two controls on the rail are in the same place — Pixel 5
      — soundbtn over walkbtn, nearbybtn over minimap
```

## One correction to my own guard, before it earned that

I first wrote it into the **desktop** context, where it passed against the broken build — because the rail is only redefined below 1023 px and the desktop never reads that block. It runs on the Pixel 5 now, and *before* walk mode is engaged, since the rail a visitor **arrives** to is the one that has to work. A check at one viewport says nothing about the others.

## Verification

`a11y` ✅ locally with the fix, both rail checks (desktop and Pixel 5). Red against `main` with the message quoted above. `css` ✅ · `cache-version` guard ✅.

Refs #82 · #89.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_