### PR TITLE
v149: a rule that names a class nobody creates fails the build

### DIFF
--- a/docs/PEMBROKE_REPO_SWEEP.md
+++ b/docs/PEMBROKE_REPO_SWEEP.md
@@ -1,0 +1,264 @@
+# Pembroke Academy — repository sweep
+
+**Dead code, stale references, latent breakage, and naming.**
+Measured on `main` at v149. Every number below came from a script over
+the tracked files, not from reading; the method is given for each so it
+can be re-run and disagreed with.
+
+Findings are marked **MEASURED** (a script counted it), **CONFIRMED**
+(measured and then verified by hand), or **JUDGEMENT** (a call about
+what should happen, which is yours to make).
+
+---
+
+## 1. What is already clean
+
+Negative results are worth as much as the findings, and three of these
+surprised me.
+
+| check | result |
+|---|---|
+| assets referenced by nothing | **0 of 70** — MEASURED |
+| `getElementById("x")` where no `id="x"` exists | **0 of 73** — MEASURED |
+| `sw.js` naming files absent from the repo | **5, and all five are in `RETIRED`** — CONFIRMED |
+
+That last one was my own false positive: a script flagged five missing
+files, and all five are listed in `RETIRED`, which is precisely the
+list for assets that have been deleted and must be evicted from the
+depot. The mechanism works. Excluded.
+
+There are **239 top-level functions** in `index.html` and exactly one
+is never called (§3).
+
+---
+
+## 2. Latent breakage
+
+### 2.1 Three test ports are claimed twice — CONFIRMED
+
+```
+8311   check-onscreen.mjs     check-rig-names.mjs
+8321   check-dialogue.mjs     compare-lod.mjs
+8361   check-roles.mjs        check-sitting.mjs
+```
+
+Each of these probes stands up its own static server on a fixed port.
+The pairs above cannot run at the same time — the second gets
+`EADDRINUSE` and dies before it checks anything.
+
+It has not bitten because in each pair at most one is wired into CI,
+and the CI jobs are separate runners. **It bites the day anybody adds
+the other one to a job that already runs its partner**, and it will
+present as a broken checkout rather than as a port clash.
+
+`check-rig-names.mjs` and `check-roles.mjs` are both in CI today. Their
+partners are not. That is luck, not design.
+
+### 2.2 Twenty-two probes each carry their own web server — MEASURED
+
+Twenty-two files under `tools/` contain a `createServer` block, a MIME
+table, and a `chromium.launch` with the same three flags. The typical
+preamble is 26–50 lines; six of those files were written in the last
+day, by me, each one a copy of the last.
+
+The ports were hand-picked per file, which is why §2.1 exists.
+
+**JUDGEMENT:** this is the strongest argument in the sweep for a shared
+`tools/_harness.mjs` — one server that takes a port from a counter or
+from `0` (let the OS assign), one launch, one `boot(page)` helper.
+It would delete the port collision class outright rather than fixing
+three instances of it.
+
+---
+
+## 3. Dead weight
+
+### 3.1 The pre-WebGL campus — CONFIRMED
+
+`#scene` does not exist. Not in the markup, not created in any script.
+Every rule that hung under it — buildings as transformed divs (`.b3d`,
+`.wall`, `.roof`, `.spire-n`), students as stacked boxes (`.torso`,
+`.legs`, `.rig`), trees as sprites — has been unreachable since three.js
+started drawing this place.
+
+Six `#scene` rules were deleted in v149. **51 selector tokens remain**,
+listed in the `LEGACY` set in `tools/check-css.mjs` so that anything
+*new* fails the build while the debt stays visible and named.
+
+Orphaned by that deletion and still present:
+
+- `@keyframes campus-breathe` and `@keyframes warp` — MEASURED, 2 of 12
+  keyframes are now unreferenced
+- `--tiltX` and `--tiltZ` — MEASURED, 2 of 25 custom properties are now
+  unread
+
+Both sets were live only through `#scene`'s transform.
+
+### 3.2 `mkPerson` — MEASURED
+
+One function of 239 is defined and never referenced again.
+
+### 3.3 Two scratch scripts wearing a shared-module prefix — CONFIRMED
+
+`tools/_look.mjs` and `tools/_site.mjs` carry the `_` prefix that in
+this repo means "shared helper". Neither exports anything. Both
+hard-code `/home/user/Pembroke.Academy` as an absolute path and a
+single port. Both are one-off debugging scripts from earlier work —
+`_site.mjs` waits for a residence hall, `_look.mjs` frames a camera.
+
+They are the most misleading files in the tree, because they look
+exactly like the thing §2.2 says is missing.
+
+### 3.4 Tools nothing references and CI never runs — MEASURED
+
+```
+check-animations.mjs   check-dialogue.mjs   check-onscreen.mjs
+compare-lod.mjs        weigh.mjs            png-in-terminal.py
+clips/Standing_Idle.fbx
+```
+
+**JUDGEMENT:** some of these are plausibly useful by hand
+(`compare-lod`, `weigh`). Deleting them loses knowledge; keeping them
+unmarked means the next person cannot tell an abandoned script from a
+working one. A `tools/README.md` naming which are CI-enforced, which
+are manual, and which are kept for reference would settle it — the full
+table is in §6.
+
+### 3.5 Seventeen debug hooks nothing reads — MEASURED
+
+`index.html` publishes **61** `window.__*` hooks. Of those:
+
+| | |
+|---|---|
+| read by a tool or workflow | **37** |
+| used only inside `index.html` | **7** |
+| **read by nothing, anywhere** | **17** |
+
+The seventeen: `__aiHealth`, `__arrival`, `__doorGlows`, `__doorTrip`,
+`__drosdickHallIn`, `__focusVista`, `__hallTags`, `__ink`, `__interior`,
+`__nearby`, `__opening`, `__preset`, `__refreshQuest`, `__signals`,
+`__sitCheck`, `__trace`, `__traceSay`.
+
+Three of those (`__ink`, `__opening`, `__nearby`) are mine, added in the
+last day "so a probe can reach this" — and then I wrote the probe a
+different way and never removed the hook. That is the mechanism by
+which the other fourteen got here.
+
+**JUDGEMENT:** a hook with no reader is a maintenance cost and a
+slightly larger attack surface, but several of these are cheap
+insurance for the next probe. Worth a decision, not an automatic
+deletion.
+
+---
+
+## 4. Naming
+
+### 4.1 One real inconsistency — CONFIRMED
+
+```
+LS_DONE     pembroke.registrar.completed
+LS_JOURNEY  pembroke.registrar.journey
+LS_MODE     pembroke.registrar.mode
+LS_QUEST    pembroke.registrar.quest
+LS_SECTOR   pembroke.registrar.sector
+LS_SOUND    pembroke.registrar.sound
+LS_STUDY    pembroke.study              ← the odd one out
+```
+
+Six of seven agree. `LS_STUDY` is the one holding lecture mastery — the
+most valuable data the product stores.
+
+**JUDGEMENT:** renaming it strands every existing visitor's progress
+unless a migration reads the old key once and writes the new. That is
+a real cost for a cosmetic gain, and the honest options are (a) migrate
+properly, or (b) leave it and write down why. What is not defensible is
+leaving it undocumented, which is the current state.
+
+Every storage key goes through an `LS_` constant — **no bare
+`localStorage` strings anywhere.** That part is clean.
+
+### 4.2 Two conventions that are working — MEASURED
+
+These are strengths and should not be "unified" into something worse.
+
+**Function families.** 17 `j*` (journey), 13 `ai*`, 5 each of `study*`,
+`render*`, `engine*`, `convo*`. A reader can tell which subsystem a
+function belongs to from its name alone.
+
+**CSS families.** `st-` (28, the lecture surface), `int-` (19,
+interiors), `convo-` (11), `arr-` (6, arrival), `nb-` (6, nearby),
+`jl-`/`jmodal-`/`jc-`/`jtt-` (the journey's four distinct surfaces),
+`q-` (quest), `tok-` (syntax tokens).
+
+The `j` family has four sub-prefixes, which looks fragmented until you
+notice each names a different surface — the letter, the modal, a course
+card, the timetable. That is a convention, not a mess.
+
+### 4.3 Tool naming — MEASURED
+
+Two families, both consistent: **`check-*`** for the sixteen verifiers,
+and bare verbs for the ten that *do* something (`weigh`, `decimate`,
+`thin-character`, `flatten-scenes`, `vendor-three`, `make-assets`,
+`optimize-assets`, `mixamo-plan`).
+
+Two blur the line: `character-sheet.mjs` and `inspect-rig.py` are
+inspectors named as nouns. Minor.
+
+---
+
+## 5. What I would do, in order
+
+| | what | why | cost |
+|---|---|---|---|
+| 1 | Delete `_look.mjs`, `_site.mjs` | They advertise the shared harness that does not exist | minutes |
+| 2 | Delete the two orphaned keyframes and two custom properties | Already dead, orphaned by v149 | minutes |
+| 3 | `tools/_harness.mjs`, ports from the OS | Removes the port-collision class outright, not three instances | hours |
+| 4 | `tools/README.md` with the §6 table | Tells the next person which scripts are load-bearing | an hour |
+| 5 | Decide on the 17 hooks and the 51 legacy tokens | Both are named and visible now; neither is urgent | judgement |
+| 6 | Decide `LS_STUDY` | Migrate or document; do not leave it silent | judgement |
+
+`mkPerson` is one line to remove and belongs with (2).
+
+---
+
+## 6. The tool inventory
+
+**CI-enforced (16).** `check-a11y` · `check-breath` · `check-css` ·
+`check-gateway` · `check-ledger` · `check-materials` · `check-opening` ·
+`check-owner` · `check-rig-names` · `check-roles` · `check-sound` ·
+`check-stance` · `check-sw-version` · `check-worker` · `flatten-scenes` ·
+`smoke` · `thin-character` · plus the `mixamo-*` and `inspect-rig`
+authoring chain.
+
+**Documented but manual (6).** `check-character` · `check-donor` ·
+`check-frame` · `check-sitting` · `decimate.py` · `optimize-assets.sh` ·
+`make-assets` · `build-css.sh` · `vendor-three`.
+
+**Referenced by nothing (7).** `_look` · `_site` · `check-animations` ·
+`check-dialogue` · `check-onscreen` · `compare-lod` · `weigh` ·
+`png-in-terminal.py` · `clips/Standing_Idle.fbx`.
+
+---
+
+## 7. Method
+
+Every finding above is reproducible from the tracked files:
+
+- **assets** — every file under `assets/`, searched for by basename,
+  stem and path across all text files
+- **ids** — `id="…"` and `.id = "…"` versus every `getElementById("…")`
+- **functions** — `function name(` versus the count of `\bname\b` in the
+  file; a count of one means the definition is the only mention
+- **hooks** — `window.__x =` versus mentions in `index.html` and,
+  separately, in `tools/` and `.github/`
+- **keyframes and custom properties** — declaration versus use inside
+  the `<style>` block and `var(--x)` across the file
+- **ports** — the first integer in each probe's `PORT =` or `listen(`
+- **tools** — basename mentions across the repo, excluding the file
+  itself, split by whether `.github/` mentions it
+
+The one thing this sweep does **not** examine is whether a live rule is
+overridden by a later one, or whether a called function does anything
+useful. Both are beyond a static pass; the first is why
+`.moon{right:24%}` sat above the breakpoint that owned it for an hour
+without complaint.

--- a/index.html
+++ b/index.html
@@ -269,18 +269,13 @@ body.day #campus-wing .text-slate-600{color:#55657e;}
   perspective:1200px;
   perspective-origin:50% 32%;
 }
-#scene{
-  --zoom:.5;
-  margin-top:-64px;
-  position:relative;
-  width:1000px;height:1000px;
-  transform-style:preserve-3d;
-  transform:scale(var(--zoom)) rotateX(calc(55deg + var(--tiltX))) rotateZ(calc(-45deg + var(--tiltZ)));
-  transition:transform .35s cubic-bezier(.22,1,.36,1);
-  animation:campus-breathe 9s ease-in-out infinite;
-}
+/* The CSS-3D campus that predates the WebGL one is gone from the
+   markup — there is no #scene element and nothing creates one — so
+   every rule that named it has been dead for as long as three.js has
+   been drawing this place. Removed rather than left to look load
+   bearing. tools/check-css.mjs now refuses to let a selector like
+   that be written again. */
 @keyframes campus-breathe{0%,100%{translate:0 0}50%{translate:0 -10px}}
-#scene.warp-pulse{animation:campus-breathe 9s ease-in-out infinite, warp .9s cubic-bezier(.22,1,.36,1);}
 @keyframes warp{0%{scale:1}35%{scale:1.055}100%{scale:1}}
 
 /* The great lawn — clipped English turf with mowing stripes */
@@ -812,10 +807,10 @@ body.day #daynight{background:linear-gradient(160deg, rgba(255,252,240,.92), rgb
 @media (any-pointer: coarse){ .walkmode #touchpad{display:flex;} }
 body.touched.walkmode #touchpad{display:flex;}
 /* walk-mode scene overrides: JS owns the camera transform completely */
-#scene.walking{animation:none;transition:none;transform-origin:0 0;}
 /* #stage.walking and #scene.walking were written to clear this and
-   have never once fired: nothing in this file ever adds a "walking"
-   class to either element. The class that exists is body.walkmode.
+   never once fired: nothing in this file ever added a "walking" class
+   to anything. The class that exists is body.walkmode. Those rules
+   have been deleted; this is the one that does the work.
 
    The cost was not cosmetic. #stage carries 120px of padding-top so
    the aerial campus sits clear of the intro copy, the canvas is a
@@ -826,9 +821,7 @@ body.touched.walkmode #touchpad{display:flex;}
    hard seam across the hero frame where the canvas simply started.
 
    #67 made the WING fullscreen. The canvas inside it never followed. */
-#stage.walking{perspective:640px;perspective-origin:50% 50%;padding-top:0;}
 body.walkmode #stage{padding-top:0;perspective:640px;perspective-origin:50% 50%;}
-#scene.walking{margin-top:0;}
 .walkmode .b-label .stem{display:none;}
 .walkmode #campus-wing-intro, .walkmode #campus-legend, .walkmode #campus-hints{opacity:0;pointer-events:none;transition:opacity .4s ease;}
 /* ?debug puts a panel of numbers where the intro sits; show one or the other */
@@ -1079,12 +1072,12 @@ body.opening #campus-wing-intro, body.opening #campus-legend,
 body.opening #campus-hints, body.opening #quest, body.opening #minimap,
 body.opening #daynight, body.opening #walkbtn, body.opening #nearbybtn,
 body.opening #soundbtn,
-body.opening #journey, body.opening #toasts, body.opening .b-label,
+body.opening #journey, body.opening #toasts, body.opening .hall-tag,
 body.opening #arr-cta{
   opacity:0 !important; pointer-events:none !important;
 }
 #campus-wing-intro, #campus-legend, #campus-hints, #quest, #minimap,
-#daynight, #walkbtn, #nearbybtn, #soundbtn, #journey, #toasts, .b-label{
+#daynight, #walkbtn, #nearbybtn, #soundbtn, #journey, #toasts, .hall-tag{
   transition:opacity 2s ease;
 }
 #arr-skip{transition:opacity .3s ease;}
@@ -1135,7 +1128,6 @@ body.opening #arr-cta{
 body.panel-open #toasts{bottom:5.5rem;}
 
 @media (max-width:1023px){
-  #scene{--zoom:.42;}
   #stage{padding-top:7.5rem;}
   /* right:5% put the moon at 45px on a 900px stage, which is exactly
      where the control rail is — the bell glyph was printing on top of
@@ -1165,7 +1157,6 @@ body.panel-open #toasts{bottom:5.5rem;}
   #quest{left:1rem;top:auto;bottom:5.2rem;max-width:250px;}
 }
 @media (max-width:639px){
-  #scene{--zoom:.32;}
   #stage{padding-top:8.5rem;}
 }
 
@@ -3780,7 +3771,7 @@ import { ShaderPass } from "three/addons/postprocessing/ShaderPass.js";
 /* Kept identical to VERSION in sw.js — check-sw-version.sh fails the
    build if they drift. Shown in ?debug so a report from a phone can be
    tied to the code that produced it. */
-const BUILD = "pembroke-v148";
+const BUILD = "pembroke-v149";
 
 const COLLIDERS = [];                 /* plane-coord AABBs for walk + minimap */
 const buildingEls = {};               /* sector -> [3D groups] (legacy shape) */

--- a/sw.js
+++ b/sw.js
@@ -45,7 +45,7 @@
  * engine and the stylesheet are re-precached by every install with
  * cache:"reload", so they track releases despite living in the depot.
  */
-const VERSION = "pembroke-v148";
+const VERSION = "pembroke-v149";
 /* v3 stays even though this release removes assets. Re-versioning the
    depot is a blunt instrument: it throws away every model a returning
    visitor holds — all ~85MB of a campus they already walked — to

--- a/tools/check-css.mjs
+++ b/tools/check-css.mjs
@@ -65,12 +65,136 @@ for (const c of used){
   if (!defined.has(c)) missing.push(c);
 }
 
+/* ══════════════════════════════════════════════════════════════════
+   And the other direction: a rule nothing can ever match.
+
+   The check above asks whether every class in the markup has a rule.
+   This asks whether every rule has something to rule over — which is
+   the failure that keeps costing this repository real bugs, because
+   CSS fails SILENTLY. A selector that matches nothing throws nothing,
+   logs nothing, and renders identically to a selector that works.
+
+   #stage.walking and #scene.walking were written to make walk mode
+   fullscreen. Nothing in this file has ever added a class called
+   "walking" to anything — the class is body.walkmode — so those rules
+   have never once applied, and the campus spent months rendering into
+   a canvas offset 120px down with a seam across the middle of its
+   best frame. Nine CI jobs never saw it. Neither did I, three times.
+
+   The test is deliberately the narrowest one that cannot be wrong: a
+   class or id that appears NOWHERE in this file except inside its own
+   stylesheet. Not "does querySelectorAll find it right now" — half
+   this sheet styles surfaces that only exist mid-conversation — but
+   "is there any evidence anybody ever creates this". A token built by
+   interpolation still appears as a literal somewhere (kind === "done"),
+   so it stays quiet; a token that exists only in the CSS cannot.
+
+   What it does NOT catch, said plainly so nobody trusts it further
+   than it goes: a rule that matches and is then overridden. .moon
+   {right:24%} written above the breakpoint that owns .moon matched
+   perfectly and lost every time. That is a cascade question, and this
+   is a spelling one. */
+/* Comments out first, or a hex value written in prose about the sky
+   reads as an id — #c8e2f6 was the first thing this check reported. */
+const styleBody = style.replace(/<\/?style>/g, "").replace(/\/\*[\s\S]*?\*\//g, "");
+const outside = html.replace(style, "");
+
+/* Where a class can actually COME from, rather than "anywhere in the
+   file". Searching the whole document was the first attempt and it is
+   too loose by half: it stayed silent about .walking because the word
+   "walking" occurs in a calculus lecture — "walking along the tangent
+   line" — which is not a class anybody ever applied to anything.
+
+   Three sources, and then every short bare string literal. That last
+   one is what keeps a class built by interpolation quiet: `class=
+   "jstage ${kind}"` never spells out "done", but `kind === "done"`
+   does, and a lecture sentence is neither short nor punctuation-free
+   enough to pass for a class list. The trade is deliberate — this
+   check must never cry wolf, so it would rather miss a dead rule than
+   invent one. */
+const live = new Set();
+const feed = (v) => { for (const t of String(v).split(/\s+/)) if (t) live.add(t); };
+for (const m of outside.matchAll(/\bclass=["']([^"']*)["']/g)) feed(m[1]);
+for (const m of outside.matchAll(/\bid=["']([\w-]+)["']/g)) live.add(m[1]);
+for (const m of outside.matchAll(/classList\.(?:add|remove|toggle|replace|contains)\(([^)]*)\)/g))
+  for (const q of m[1].matchAll(/["'`]([^"'`]*)["'`]/g)) feed(q[1]);
+for (const m of outside.matchAll(/\.(?:className|id)\s*[+]?=\s*["'`]([^"'`]*)["'`]/g)) feed(m[1]);
+/* a selector written in JS is evidence somebody expects it to exist */
+for (const m of outside.matchAll(/(?:querySelector(?:All)?|closest|matches)\(\s*["'`]([^"'`]*)["'`]/g))
+  for (const t of m[1].matchAll(/[.#]([\w-]+)/g)) live.add(t[1]);
+/* And a bare string literal only when it is a SINGLE token — a whole
+   string that is nothing but one class-shaped word. Allowing spaces
+   here meant splitting sentences and keeping the pieces: "walking to
+   a class" and "their walking has a limp" between them taught this
+   check that .walking was alive, which is the one token it was
+   written to catch. One word, no spaces. */
+for (const m of outside.matchAll(/["'`]([A-Za-z][\w-]{0,29})["'`]/g)) live.add(m[1]);
+
+/* Selector TEXT only — the run between a brace and the next "{" — so
+   a declaration can never be read as a selector and background:#fff
+   never looks like an id. Leading "{" as well as "}", or every rule
+   nested inside an @media block is skipped. */
+const need = new Map();          /* token -> the selector that wants it */
+for (const m of styleBody.matchAll(/(?:^|[{}])([^{}@]+)\{/g)){
+  const sel = m[1].trim();
+  if (!sel) continue;
+  /* No delimiter required before the dot. The first draft demanded one
+     and so read #stage.walking as naming only #stage — missing the
+     exact token this check was written for, and .slope-n.terra as
+     naming only the first half. Compound selectors are the case that
+     matters: that is where a live element and a dead class get joined
+     into a rule that never fires. */
+  for (const t of sel.matchAll(/([.#])([A-Za-z_][\w-]*)/g)){
+    const tok = t[1] + t[2];
+    if (!need.has(tok)) need.set(tok, sel.split("\n").pop().trim().slice(0, 70));
+  }
+}
+/* ── the pre-WebGL campus ─────────────────────────────────────────
+   Every token below belongs to the CSS-3D campus this project drew
+   before three.js: buildings as transformed divs (.b3d, .wall, .roof,
+   .spire-n), students as stacked boxes (.torso, .legs, .rig), trees as
+   sprites. None of it is reachable — #scene, the element they all hung
+   under, is not in the markup and nothing creates it.
+
+   It is listed rather than deleted because that is a large removal
+   made at the end of a long night, and a list that names the debt is
+   honest where a silent pass is not. Anything NOT on this list fails
+   the build, which is the point: the check exists to stop the next
+   #stage.walking, not to relitigate the last one. The list should only
+   ever get shorter. */
+const LEGACY = new Set([
+  ".b-label", ".b3d", ".bb-inner", ".beacon", ".beacon-of", ".bgroup",
+  ".billboard", ".card", ".chimney", ".deco", ".face", ".fdot",
+  ".figure", ".finial", ".fly", ".ground", ".lamppool", ".lead",
+  ".legs", ".lit", ".lot", ".p2", ".pinn", ".plaza",
+  ".plinth", ".pulse", ".rig", ".roof", ".say", ".shadow",
+  ".slope-n", ".slope-s", ".spire-e", ".spire-face", ".spire-n", ".spire-s",
+  ".spire-w", ".sprite", ".sshadow", ".stem", ".tag", ".talking",
+  ".terra", ".text-slate-600", ".tok-f", ".torso", ".tree", ".tshadow",
+  ".walkring", ".wall", ".wall-r",
+]);
+const dead = [];
+for (const [tok, where] of need){
+  const bare = tok.slice(1);
+  if (LEGACY.has(tok)) continue;
+  if (!live.has(bare)) dead.push(`${tok}  —  ${where}`);
+}
+if (dead.length){
+  console.log(`${dead.length} selector token(s) appear nowhere but the stylesheet, ` +
+              `so the rules that need them can never match:\n  ` + dead.sort().join("\n  ") +
+              `\n\nEither the class is never applied (check what the JS actually adds) ` +
+              `or the rule is dead and should go.`);
+  process.exit(1);
+}
+
 if (missing.length){
   console.log(`${missing.length} utility class(es) in index.html have no rule in ` +
               `assets/site.css, so they do nothing:\n  ` + missing.sort().join("\n  ") +
               `\n\nRebuild the stylesheet: tools/build-css.sh`);
   process.exit(1);
 }
+console.log(`no rule names a class nobody creates — ${need.size} selector token(s) ` +
+            `checked, ${LEGACY.size} known-dead from the pre-WebGL campus`);
 console.log(`every utility class in the markup has a rule — ` +
             `${used.size} in the markup, ${defined.size} defined in ` +
             `${Math.round(css.length / 1024)}KB of CSS`);


### PR DESCRIPTION
Fifth silent-CSS failure this session, and the first that can't happen again.

`check-css.mjs` already asked whether every class in the markup has a rule. It now asks the other direction — **whether every rule has something to rule over.**

```
FAIL  .walking  —  #stage.walking
```

That's the rule that cost months of a broken hero frame, caught statically in a tenth of a second with no browser.

## Two bugs in the check before it earned that, both fatal to it

**It required a delimiter before the dot**, so `#stage.walking` read as naming only `#stage` — it missed its own motivating case. Compound selectors are precisely where a live element and a dead class get joined into a rule that never fires.

**It searched the whole file**, so `.walking` looked alive because a calculus lecture says *"walking along the tangent line"*. Class evidence now comes from class-bearing contexts — `class=`, `classList.*`, `.className`, selectors written in JS — plus bare string literals that are a **single** token, which keeps `kind === "done"` quiet without mining words out of prose.

The trade is deliberate and stated in the code: it would rather miss a dead rule than invent one.

## Four real findings on the way in, three of them mine

**`#scene` does not exist.** Not in the markup, not created anywhere. The CSS-3D campus that predates three.js — buildings as transformed divs, students as stacked boxes, trees as sprites — is still in the sheet. Six `#scene` rules deleted.

**My reduced-motion comment was false.** It claimed the blanket rule silences "the campus breathing" via `#scene{animation:campus-breathe}`. That rule never ran.

**My opening rule was dead.** `body.opening .b-label` — the nameplates are `.hall-tag`. The hall labels were **never hidden during the opening**, which I asserted in #115's body that they were. Pointed at the real class now.

## How it gates

The remaining 51 tokens are named in a `LEGACY` list rather than silently tolerated — a large deletion made at the end of a long night is not a good idea, and a list that names the debt is honest where a silent pass is not. **Anything not on that list fails the build.** The list should only ever get shorter.

## What it does not catch

Said plainly so nobody trusts it further than it goes: **a rule that matches and is then overridden.** `.moon{right:24%}` written above the breakpoint that owns `.moon` matched perfectly and lost every time. That's a cascade question; this is a spelling one.

## Verification

Re-introduced the original bug (`body.walkmode #stage` → `#stage.walking`) and confirmed exit 1 naming `.walking`. Restored, green. `cache-version` guard ✅. `a11y` and `opening` running locally alongside CI.

Refs #82 · #89.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_