### PR TITLE
Keep the keyboard on the person it was on when they walk indoors

### DIFF
--- a/index.html
+++ b/index.html
@@ -710,8 +710,12 @@ body.day #daynight{background:linear-gradient(160deg, rgba(255,252,240,.92), rgb
   padding:.35rem .3rem .3rem;}
 .nb-row{display:block;width:100%;text-align:left;padding:.42rem .5rem;border-radius:.5rem;
   border:1px solid transparent;color:#e2e8f0;cursor:pointer;background:none;}
-.nb-row:hover:not(:disabled){background:rgba(212,175,106,.12);border-color:rgba(212,175,106,.32);}
-.nb-row:disabled{opacity:.45;cursor:default;}
+.nb-row:hover:not([aria-disabled]){background:rgba(212,175,106,.12);border-color:rgba(212,175,106,.32);}
+/* aria-disabled, NOT the disabled attribute. A disabled button cannot
+   be focused at all, and somebody who walks indoors while the keyboard
+   is resting on their row would take the focus with them — see the
+   restore in nearbyRender. Dimmed, unactivatable, still reachable. */
+.nb-row[aria-disabled]{opacity:.45;cursor:default;}
 .nb-name{display:block;font-size:12.5px;}
 .nb-meta{display:block;font-size:10.5px;color:#94a3b8;}
 .nb-where{display:block;font-size:10.5px;color:var(--brass-dim);}
@@ -14788,7 +14792,7 @@ function nearbyRender(){
   const peopleHtml = people.length
     ? people.map(r => {
         const ai = r.s.data.ai || {};
-        return `<button class="nb-row" data-talk="${escA(r.s.data.name)}"${r.out ? "" : " disabled"}>
+        return `<button class="nb-row" data-talk="${escA(r.s.data.name)}"${r.out ? "" : ' aria-disabled="true"'}>
           <span class="nb-name">${esc(r.s.data.name)}</span>
           <span class="nb-meta">${esc([ai.year, r.s.data.major].filter(Boolean).join(" · "))}</span>
           <span class="nb-where">${esc(where(r))}</span></button>`;
@@ -14823,8 +14827,18 @@ function nearbyRender(){
   placesEl.innerHTML = placesHtml;
   if (!key) return;
   const [kind, val] = [key.slice(0, key.indexOf(":")), key.slice(key.indexOf(":") + 1)];
-  const again = nearbyEl.querySelector(`[data-${kind}="${CSS.escape(val)}"]:not([disabled])`);
-  (again || nearbyEl.querySelector(".nb-row:not([disabled])"))?.focus();
+  /* No :not() on THIS lookup. It used to carry one, and that is how the
+     keyboard ended up on a stranger: somebody the reader was standing on
+     walks into a building, their row is still listed but is now dimmed,
+     the identity lookup misses it, and the fallback below hands the
+     keyboard to whoever happens to be first in the list. Measured:
+     stood on "Elowen", ended on "Prof. Merion", and Enter would have
+     opened a conversation with the wrong person. Now the row is only
+     aria-disabled, so it still takes focus and the reader stays where
+     they were — dimmed, and told so. The fallback is for a row that has
+     genuinely gone. */
+  const again = nearbyEl.querySelector(`[data-${kind}="${CSS.escape(val)}"]`);
+  (again || nearbyEl.querySelector(".nb-row:not([aria-disabled])"))?.focus();
 }
 function nearbyToggle(force){
   const open = force === undefined ? nearbyEl.hidden : !!force;
@@ -14837,7 +14851,7 @@ function nearbyToggle(force){
     nearbyRender();
     /* people walk while the list is up, so the list walks with them */
     nearbyTimer = setInterval(nearbyRender, 1500);
-    nearbyEl.querySelector(".nb-row:not([disabled])")?.focus();
+    nearbyEl.querySelector(".nb-row:not([aria-disabled])")?.focus();
   } else if (held) nearbyBtn.focus();   /* only if it was ours to give back */
 }
 nearbyBtn.addEventListener("click", () => nearbyToggle());
@@ -14845,6 +14859,11 @@ nearbyEl.addEventListener("keydown", e => { if (e.key === "Escape") nearbyToggle
 nearbyEl.addEventListener("click", e => {
   const t = e.target.closest("[data-talk],[data-enter]");
   if (!t) return;
+  /* aria-disabled is a promise to the reader, not to the browser: unlike
+     the disabled attribute it suppresses nothing, so the row that says
+     it cannot be activated has to refuse here. Covers Enter and Space
+     too — both arrive as a click on a button. */
+  if (t.getAttribute("aria-disabled") === "true") return;
   nearbyToggle(false);
   if (t.dataset.enter){ openInterior(t.dataset.enter); return; }
   const s = students.find(x => x.data?.name === t.dataset.talk);

--- a/tools/check-a11y.mjs
+++ b/tools/check-a11y.mjs
@@ -355,7 +355,7 @@ try {
     return { up: !el.hidden,
              expanded: document.getElementById("nearbybtn").getAttribute("aria-expanded"),
              people: el.querySelectorAll("#nb-people .nb-row").length,
-             reachable: el.querySelectorAll("#nb-people .nb-row:not([disabled])").length,
+             reachable: el.querySelectorAll("#nb-people .nb-row:not([aria-disabled])").length,
              places: el.querySelectorAll("#nb-places .nb-row").length,
              focusInside: el.contains(document.activeElement) };
   });
@@ -367,7 +367,7 @@ try {
   /* every named person the ray could reach must have a control here */
   const covered = await page.evaluate(() => {
     const named = window.__students.filter(s => s.data?.name && s.g?.visible).map(s => s.data.name);
-    const listed = [...document.querySelectorAll("#nb-people .nb-row:not([disabled]) .nb-name")]
+    const listed = [...document.querySelectorAll("#nb-people .nb-row:not([aria-disabled]) .nb-name")]
       .map(e => e.textContent);
     return { missing: named.filter(n => !listed.includes(n)), named: named.length };
   });
@@ -383,7 +383,7 @@ try {
      immediately, so none of them ever waited long enough to be thrown
      out. This one waits through two refreshes on purpose. */
   const kept = await page.evaluate(async () => {
-    const rows = [...document.querySelectorAll("#nb-people .nb-row:not([disabled])")];
+    const rows = [...document.querySelectorAll("#nb-people .nb-row:not([aria-disabled])")];
     const target = rows[rows.length - 1] || rows[0];
     if (!target) return { ok: false, why: "no reachable row to stand on" };
     target.focus();
@@ -396,8 +396,49 @@ try {
   step("the list refreshing does not throw the keyboard out of it", kept.ok,
        kept.why || `stood on ${JSON.stringify(kept.was)}, ended on ${JSON.stringify(kept.now)}`);
 
+  /* …and the same question asked so it cannot pass by luck.
+     The check above waits two refreshes and hopes somebody walks
+     indoors during them. That is the ONLY condition under which the
+     bug it guards fires, so on a quiet quad it passes without ever
+     testing anything — which is how the defect reached CI, and how a
+     lucky green would then have hidden it again. Here the person the
+     keyboard is standing on is walked indoors ON PURPOSE.
+
+     "Gone dim" is read from aria-disabled OR the disabled attribute,
+     deliberately: this asks whether the KEYBOARD SURVIVES somebody
+     stepping inside, not how the row was marked. Either marking may
+     answer it. And if the row never goes dim at all, that is a
+     FAILURE rather than a pass — the scenario did not happen and the
+     check learned nothing. */
+  const dimmed = await page.evaluate(async () => {
+    const rows = [...document.querySelectorAll(
+      "#nb-people .nb-row:not([aria-disabled]):not([disabled])")];
+    if (rows.length < 2) return { exercised: false, why: `only ${rows.length} reachable row(s) to work with` };
+    const target = rows[rows.length - 1];
+    target.focus();
+    const was = target.dataset.talk, first = rows[0].dataset.talk;
+    const s = window.__students?.find(x => x.data?.name === was);
+    if (!s) return { exercised: false, why: `no student behind the row for ${was}` };
+    s.g.visible = false;                       /* they step inside */
+    window.__nearby.render();
+    const row = document.querySelector(`[data-talk="${CSS.escape(was)}"]`);
+    const dim = !!row && (row.getAttribute("aria-disabled") === "true" || row.hasAttribute("disabled"));
+    const now = document.activeElement;
+    s.g.visible = true;                        /* put them back */
+    return { exercised: dim, why: dim ? null : "the row never went dim — the scenario did not happen",
+             was, first, now: now?.dataset?.talk ?? now?.tagName?.toLowerCase() ?? "nothing",
+             inPanel: document.getElementById("nearby").contains(now) };
+  });
+  step("and somebody walking indoors does not take the keyboard with them",
+       dimmed.exercised && dimmed.now === dimmed.was && dimmed.inPanel,
+       dimmed.why || `stood on ${JSON.stringify(dimmed.was)}, they stepped inside, keyboard ended on ` +
+                     `${JSON.stringify(dimmed.now)}` +
+                     (dimmed.now === dimmed.was ? " — stayed, dimmed and still reachable"
+                      : dimmed.now === dimmed.first ? " — the FIRST row: focus fell through to a different person"
+                      : " — focus left the row it was on"));
+
   const talked = await page.evaluate(async () => {
-    document.querySelector("#nb-people .nb-row:not([disabled])").click();
+    document.querySelector("#nb-people .nb-row:not([aria-disabled])").click();
     await new Promise(r => setTimeout(r, 600));
     const on = document.body.classList.contains("convo-open");
     if (on) document.getElementById("convo-cancel")?.click();


### PR DESCRIPTION
**Blocks #120.** The `a11y` gate went red there on a defect #120 did not cause — the nearby list is untouched by that diff and the same code is on `main`. This fixes it so #120 can merge on a real pass rather than a lucky one.

## What CI caught

```
FAIL  the list refreshing does not throw the keyboard out of it
      — stood on "Elowen", ended on "Priya"
```

19 of 20 a11y checks passed. This one is about the nearby panel: stand the keyboard on someone, let the list refresh, and the keyboard should still be on them.

## Root cause

`index.html:14785`. The list refreshes every 1.5s because people walk, and the restore after the rewrite looks the held row up **by identity** — which the comment above it correctly claims. It also carried a `:not()` the comment did not mention:

```js
const again = nearbyEl.querySelector(`[data-${kind}="${CSS.escape(val)}"]:not([disabled])`);
(again || nearbyEl.querySelector(".nb-row:not([disabled])"))?.focus();
```

A person who steps into a building becomes `disabled` (`out: s.g.visible`). Their row is **still listed**, deliberately — *"a name that vanishes from a list looks like a name that does not exist"* — but the identity lookup now misses it, and the fallback beneath hands the keyboard to whoever happens to be first.

**Reproduced deterministically** by walking the held person indoors on purpose:

```
stoodOn: "Elowen"  →  endedOn: "Prof. Merion"    ← the FIRST row: the fallback fired
heldRowStillListed: true      heldRowNowDisabled: true
```

## Why it matters more than "focus was lost"

The reader is not merely dropped out of the panel — they are silently moved onto **a different person**, with the panel still open and looking correct. Press Enter and a conversation opens with someone you never selected. A lost place is recoverable; a wrong action taken on your behalf is not, and nothing announces that anything moved.

## The fix

`aria-disabled="true"` instead of the `disabled` attribute. A `disabled` button **cannot take focus at all**, so simply dropping the `:not()` would have re-created the original bug this code was written to fix. `aria-disabled` dims the row, announces it as unavailable, and keeps it focusable — so the reader stays exactly where they were.

Five places move together, and they have to:

| | |
|---|---|
| the row markup | `disabled` → `aria-disabled="true"` |
| two CSS rules | `:disabled` → `[aria-disabled]` |
| the identity lookup | drops its `:not()` — the row is now focusable either way |
| the panel's opening focus | still lands on somebody you can actually talk to |
| **the click handler** | `aria-disabled` is a promise to the reader, not to the browser: unlike `disabled` it suppresses nothing, so the row that says it cannot be activated has to refuse. Covers Enter and Space too — both arrive as a click on a button. |

The global `:where(button):focus-visible` rule already covers `.nb-row`, so a dimmed row that takes focus still wears the brass ring. axe is clean on it: `aria-disabled` is valid on `button`.

## The check could not have caught this reliably

The existing check waits two refreshes and **hopes** somebody walks indoors during them. That is the only condition under which the bug fires, so on a quiet quad it passes without testing anything. That is how the defect reached CI in the first place — and a lucky green would have hidden it again.

A second check now walks the held person inside **on purpose**, and treats *"the row never went dim"* as a **failure** rather than a pass, so it cannot go vacuous the same way. It reads "gone dim" from `aria-disabled` **or** the `disabled` attribute deliberately: the question is whether the keyboard survives somebody stepping inside, not how the row was marked.

## Verified in both directions

**On the unfixed page**, with the new check present:

```
ok    the list refreshing does not throw the keyboard out of it  — stood on "Priya", ended on "Priya"
FAIL  and somebody walking indoors does not take the keyboard with them
      — stood on "Priya", they stepped inside, keyboard ended on "Elowen"
      — the FIRST row: focus fell through to a different person
```

The old check **passing on the broken page in that same run** is the vacuous pass, on the record.

**On the fixed page:**

```
ok  the list refreshing does not throw the keyboard out of it  — stood on "Elowen", ended on "Elowen"
ok  and somebody walking indoors does not take the keyboard with them
    — stood on "Elowen", they stepped inside, keyboard ended on "Elowen"
    — stayed, dimmed and still reachable
```

**21 accessibility checks pass**, axe clean on desktop and Pixel 5. `check-css` and `check-sw-version` green.

## No version bump

Nothing under `assets/` changed, so the guard does not ask for one. `BUILD`/`VERSION` stay at `v149` deliberately, so this does not collide with the v150 bump waiting in #120.

## Merge order

1. **this PR** → `main`
2. **#120** (v150 harness) — rebase or merge `main` in, then it goes green on a real pass
3. **#121** (the integrity audit) — retargets to `main` automatically once #120 lands

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_