### PR TITLE
The day/night check pressed past the thing it was waiting for

### DIFF
--- a/tools/smoke.mjs
+++ b/tools/smoke.mjs
@@ -69,10 +69,19 @@ const shoot = async (path) => {
 /* CI has no GPU and 80MB of models decode on the main thread, so the
    page can be wedged for seconds at a time. Re-check before re-pressing
    so a toggle key is never fired twice, and give the world room. */
+/* Read BEFORE pressing, and never press on a read that FAILED.
+   Every key this drives toggles or advances something, so a press is
+   not idempotent and cannot be taken back. A page stalled mid-GLB-parse
+   answers no evaluate at all, and treating that silence as "not there
+   yet" spends a press on a state we never saw. Wait the stall out
+   instead: the deadline still bounds the whole thing. */
 const pressUntil = async (key, predicate, budgetMs = 150_000) => {
   const deadline = Date.now() + budgetMs;
   while (Date.now() < deadline){
-    if (await page.evaluate(predicate).catch(() => false)) return true;
+    let here;
+    try { here = await page.evaluate(predicate); }
+    catch { await page.waitForTimeout(1000); continue; }   /* stalled, not absent */
+    if (here) return true;
     await page.keyboard.press(key).catch(() => {});
     const ok = await page.waitForFunction(predicate, null, { timeout: 15_000 })
       .then(() => true, () => false);
@@ -644,22 +653,43 @@ try {
   step("panel closes",
        await pressUntil("Escape", () => !document.querySelector(".interior-open"), 60_000));
 
-  /* The clock cycles day → golden → night → auto; press until night
-     lands. Polled on a TIMER, not the default requestAnimationFrame:
-     landmark arrivals stage textures across frames now, and under
-     swiftshader those frames stall for seconds — the mode walked
-     THROUGH night while no frame ticked inside the window, the wait
-     timed out, and the next press moved off night again. The campus's
-     night was fine; the poll was blind. */
-  let night = false;
-  for (let i = 0; i < 6 && !night; i++){
-    await page.keyboard.press("n").catch(() => {});
-    night = await page.waitForFunction(() => window.__visual === "night", null,
-        { timeout: 25_000, polling: 500 })
-      .then(() => true, () => false);
-  }
-  step("day/night cycle reaches night", night,
-       await page.evaluate(() => window.__visual).catch(() => "?"));
+  /* THE CLOCK. Two questions, asked separately on purpose, because the
+     one check that used to ask them together could not say which half
+     had broken — and intermittently failed on neither.
+
+     It pressed first and asked afterwards, in its own loop rather than
+     through pressUntil, so it had no pre-check: every retry ADVANCED a
+     five-state cycle that it believed it was re-attempting. Miss the
+     observation once and the press still landed, so the next press
+     walked PAST night rather than back to it. Six presses around
+     ["live","day","golden","night","auto"] return you one step from
+     where you began — and "day" is exactly what it reported.
+
+     It also watched the wrong thing. window.__visual is the sky as
+     RENDERED, and it reads "day" for three different reasons: the mode
+     is day, the mode is `live` and the visitor's wall clock says
+     daytime, or the mode is `auto` mid-sweep. Two of those are not
+     failures. The MODE is the deterministic thing — set synchronously
+     by the click handler, published in the control's own title — so
+     that is what drives the loop now, through pressUntil, which has
+     checked before pressing all along. */
+  const atNight = () => /Time of day: night\b/.test(
+    document.getElementById("daynight")?.title || "");
+  const reached = await pressUntil("n", atNight, 120_000);
+  const modeNow = await page.evaluate(() =>
+    (document.getElementById("daynight")?.title.match(/Time of day: (\w+)/) || [, "?"])[1]
+  ).catch(() => "?");
+  step("the clock control reaches night", reached, `mode reads ${modeNow}`);
+
+  /* …and only now, from a mode we know, does the sky get asked. This is
+     the half that is actually about the campus: night is selected, so
+     the render must follow. Failing HERE means the campus did not go
+     dark; failing above means the control never got there. */
+  const dark = reached && await page.waitForFunction(() => window.__visual === "night",
+      null, { timeout: 60_000, polling: 500 }).then(() => true, () => false);
+  step("and the campus actually goes dark", dark,
+       reached ? `mode night · __visual ${await page.evaluate(() => window.__visual).catch(() => "?")}`
+               : "not asked — the control never reached night");
 
   step("no console errors or failed assets", errors.length === 0,
        errors.slice(0, 5).join(" | "));


### PR DESCRIPTION
```
FAIL  day/night cycle reaches night  — day
```

Read as a flake for as long as it has existed. **It is not one.** Two defects in the check, and the second explains the exact word in that failure message.

## 1. It pressed before it looked

Every other key in `smoke.mjs` goes through `pressUntil`, which reads the predicate **before** spending a press and always has. The clock had its own loop that pressed first and asked afterwards:

```js
for (let i = 0; i < 6 && !night; i++){
  await page.keyboard.press("n").catch(() => {});
  night = await page.waitForFunction(() => window.__visual === "night", …);
}
```

So every "retry" it believed it was making was in fact another **advance of a five-state cycle**. Miss the observation once and the press still landed — the next one walks *past* night rather than back to it.

**Measured**, six presses with the observation never counted:

```
live → day → golden → night → auto → live → day
started live, ended day — WALKED PAST NIGHT and ended on day
```

It reaches night on press three and then leaves. Ending on `day` is not the campus failing to darken; it is the check having been there and gone. **`day` is exactly what CI printed.**

## 2. It watched the wrong thing

`window.__visual` is the sky as **rendered**, and it reads `"day"` for three different reasons:

| | |
|---|---|
| the mode is `day` | a real answer |
| the mode is `live` | the visitor's own wall clock says daytime — **not a failure** |
| the mode is `auto` | mid-sweep — **not a failure** |

The **mode** is the deterministic fact: set synchronously by the click handler, persisted, and published in the control's own `title`.

## The fix

The loop drives on the mode, through `pressUntil`, and the check splits in two:

```
the clock control reaches night      ← did the control get there
and the campus actually goes dark    ← did the render follow
```

One is about input, the other about the campus. The old check conflated them and on failure could tell you neither.

## `pressUntil` hardened, for all five callers

It no longer spends a press on a read that **failed**:

```js
let here;
try { here = await page.evaluate(predicate); }
catch { await page.waitForTimeout(1000); continue; }   /* stalled, not absent */
if (here) return true;
```

A page stalled mid-GLB-parse answers no `evaluate` at all, and `.catch(() => false)` turned that silence into *"not there yet"* — which, for keys that toggle or advance, buys a state change nobody asked for. It waits the stall out instead; the deadline still bounds the whole thing.

## A note on the old comment

It described the cycle as `day → golden → night → auto`. There are **five** states, and the one it omits — `live` — is the one the campus starts in. A four-state mental model makes six presses look like they must land somewhere sensible.

## Verified against the running campus

| | |
|---|---|
| **old shape** | started `live`, six presses, ended `day` — walked past night |
| **new shape** | started `live`, **3 presses**, mode `night`, `__visual` `night`, campus actually dark |

## Why this is worth its own PR

This check has failed on at least two unrelated PRs today, including one whose diff was **markdown only**, while the identical sha passed in the sibling run. Every one of those costs a re-run and teaches everybody that a red `smoke` might mean nothing — which is the expensive part.

Docs-and-tooling only; `tools/smoke.mjs` is the sole file. No production code, no version bump.

## Merge order

This is independent of #120, #121 and #122 — different file, no overlap. It can land whenever.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_