### PR TITLE
Declare the two font tokens that were read but never existed

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,6 +118,19 @@ if ("serviceWorker" in navigator){
   --parchment:#e8e3d5;
   --brass:#d4af6a;
   --brass-dim:#8a744a;
+  /* The three faces this page loads, as tokens.
+     They existed only as utility classes (.font-serif-d, .font-mono-d)
+     and as the family named directly in a dozen rules — so the two
+     rules that read them THROUGH a variable, .jpanel h3 and
+     .jcourse .jc-code, resolved to nothing and quietly took their
+     fallbacks. Measured on the live journey panel: the heading
+     rendered in "Georgia, serif" with Cormorant Garamond loaded,
+     available, and passing document.fonts.check in the same document.
+     var(--x, fallback) is what made that invisible — valid CSS, a
+     sensible default, no error, wrong face. tools/check-css.mjs now
+     refuses a var() that resolves to nothing. */
+  --font-serif:'Cormorant Garamond',Georgia,serif;
+  --font-mono:'JetBrains Mono',ui-monospace,monospace;
   /* ── the four pigments ────────────────────────────────────────
      These were amber, electric blue, emerald and imperial purple —
      which is Tailwind's default accent ramp, the palette of a status

--- a/tools/check-css.mjs
+++ b/tools/check-css.mjs
@@ -187,6 +187,62 @@ if (dead.length){
   process.exit(1);
 }
 
+/* ── does every var(--x) resolve to a declaration? ────────────────────
+   The check above asks whether a SELECTOR names something live. This
+   asks the same question one level down, about custom properties, and
+   it exists because the answer was no in two places nobody could see.
+
+   .jpanel h3 read var(--font-serif, Georgia, serif) and .jcourse
+   .jc-code read var(--font-mono, monospace). Neither property was
+   declared anywhere in this repository. Measured on the live journey
+   panel: the heading rendered in "Georgia, serif" while Cormorant
+   Garamond was loaded, available, and passing document.fonts.check in
+   the same document.
+
+   Nothing could have caught it. var(--x, fallback) is valid CSS with a
+   sensible default: it does not warn, does not error, and produces a
+   page that looks finished — in the wrong face, on the registrar
+   surface. A fallback is a promise that the token exists and this is
+   the spare; when the token never existed, the spare is simply the
+   design, silently.
+
+   Two exemptions, both real:
+     INLINE     set per-element from a style attribute or setProperty,
+                so a stylesheet declaration would be wrong.
+     LEGACY_VARS  read only by the pre-WebGL rules the LEGACY set above
+                already names. Same debt, same fence, one level down. */
+const INLINE = new Set(["--c", "--ct", "--glow", "--plate"]);
+const LEGACY_VARS = new Set([
+  "--bb",         /* .bb-inner            */  "--dx",  /* @keyframes firefly  */
+  "--dy",         /* @keyframes firefly   */  "--fc",  /* .finial .fdot       */
+  "--s",          /* @keyframes tree-sway */  "--t",   /* .fly                */
+  "--tex-noise",  /* .walk::after         */  "--tex-shingle", /* .slope-*    */
+]);
+/* Comments blanked rather than removed, so offsets — and therefore the
+   line numbers reported below — still point at the real file. Prose
+   discussing a var() is not a var(): the paragraph above this check
+   contains one, and the first draft flagged its own explanation. */
+const noComments = (t) => t.replace(/\/\*[\s\S]*?\*\//g, (m) => " ".repeat(m.length));
+const declaredVars = new Set([...noComments(style).matchAll(/(--[\w-]+)\s*:/g)].map(m => m[1]));
+const readVars = new Map();
+for (const m of noComments(html).matchAll(/var\(\s*(--[\w-]+)/g)){
+  const line = html.slice(0, m.index).split("\n").length;
+  if (!readVars.has(m[1])) readVars.set(m[1], line);
+}
+const unresolved = [];
+for (const [v, line] of readVars){
+  if (declaredVars.has(v) || INLINE.has(v) || LEGACY_VARS.has(v)) continue;
+  unresolved.push(`${v}  —  first read at index.html:${line}`);
+}
+if (unresolved.length){
+  console.log(`${unresolved.length} custom propert(ies) are read through var() but ` +
+              `declared nowhere, so every rule that reads one silently takes its ` +
+              `fallback:\n  ` + unresolved.sort().join("\n  ") +
+              `\n\nDeclare it in :root, or — if it is genuinely set per-element — ` +
+              `add it to INLINE in this file and say where it is set.`);
+  process.exit(1);
+}
+
 if (missing.length){
   console.log(`${missing.length} utility class(es) in index.html have no rule in ` +
               `assets/site.css, so they do nothing:\n  ` + missing.sort().join("\n  ") +
@@ -195,6 +251,9 @@ if (missing.length){
 }
 console.log(`no rule names a class nobody creates — ${need.size} selector token(s) ` +
             `checked, ${LEGACY.size} known-dead from the pre-WebGL campus`);
+console.log(`every var() resolves to a declaration — ${readVars.size} read, ` +
+            `${declaredVars.size} declared, ${INLINE.size} set per-element, ` +
+            `${LEGACY_VARS.size} known-dead from the pre-WebGL campus`);
 console.log(`every utility class in the markup has a rule — ` +
             `${used.size} in the markup, ${defined.size} defined in ` +
             `${Math.round(css.length / 1024)}KB of CSS`);


### PR DESCRIPTION
**Repairs 1 and 2** of `docs/REPO_INTEGRITY_AUDIT.md` §14 — PR A of the recommended sequence. Shipped together on purpose: the two-line fix without the gate is one grep away from regressing.

## The defect

```css
.jpanel h3        { font-family: var(--font-serif, Georgia, serif); }
.jcourse .jc-code { font-family: var(--font-mono,  monospace); }
```

**Neither property was declared anywhere in this repository.** Measured on the live journey panel, before this change:

```
.jpanel h3   → "Georgia, serif"        CormorantLoaded: true
--font-serif → (empty)                 --font-mono → (empty)
```

Cormorant Garamond is fetched, loaded, and passes `document.fonts.check` **in the same document** — and the heading beside it renders in Georgia. The site's faces existed only as utility classes (`.font-serif-d`, `.font-mono-d`) and as families named directly in a dozen rules. These two were authored against a token system nobody built.

## Why nothing caught it

This is the part worth reading. `var(--x, fallback)` is valid CSS with a sensible default: it does not warn, does not error, and produces a page that looks finished — in the wrong face, on the registrar surface, which is the most typographically deliberate thing in the product and the one being redesigned under #89.

A fallback is a promise that the token exists and this is the spare. **When the token never existed, the spare quietly became the design.**

## The gate

`tools/check-css.mjs` now fails a `var()` that resolves to nothing. The stylesheet already had a check asking whether a *selector* names something live; this asks the same question one level down.

Two exemptions, both real, both named in the file:

| | |
|---|---|
| **`INLINE`** | `--c`, `--ct`, `--glow`, `--plate` — set per-element from a `style` attribute or `setProperty`, so a stylesheet declaration would be *wrong* |
| **`LEGACY_VARS`** | `--bb`, `--dx`, `--dy`, `--fc`, `--s`, `--t`, `--tex-noise`, `--tex-shingle` — read only by pre-WebGL rules the existing `LEGACY` set already fences |

Every one of those eight was **traced to the rules that read it** — `.bb-inner`, `.finial .fdot`, `.fly`, `.slope-n`/`.slope-s`, `@keyframes firefly`, `@keyframes tree-sway` — and checked against the `LEGACY` fence before being exempted. None was assumed dead. Anything *new* fails the build, which is the point.

Comments are blanked rather than stripped when scanning, so the reported line numbers still point at the real file — and because prose discussing a `var()` is not a `var()`. The first draft flagged its own explanation.

## Verified in both directions

**Declarations removed, gate in place** — the original defect, caught exactly:

```
2 custom propert(ies) are read through var() but declared nowhere,
so every rule that reads one silently takes its fallback:
  --font-mono   — first read at index.html:1271
  --font-serif  — first read at index.html:1207
exit 1
```

**With them:**

```
.jpanel h3 → "Cormorant Garamond", Georgia, serif
every var() resolves to a declaration — 37 read, 27 declared,
4 set per-element, 8 known-dead from the pre-WebGL campus
```

## Scope

`index.html` (two declarations plus the note explaining them) and `tools/check-css.mjs` (the gate). No version bump — nothing under `assets/` changed.

Independent of #120, #121 and #123. The `:root` edit sits ~10 lines above the `--tiltX`/`--tiltZ` removal in #120, so a merge is expected to be clean; I'll verify rather than assume when the order resolves.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_