### PR TITLE
The pixel ratio had five writers and no owner

### DIFF
--- a/index.html
+++ b/index.html
@@ -3786,7 +3786,30 @@ const stageEl = document.getElementById("stage");
 const wingEl  = document.getElementById("campus-wing");
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
-renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+/* THE PIXEL RATIO, IN ONE PLACE.
+   Three things have an opinion: the device (its ceiling, capped at 2 —
+   beyond that nobody can see the difference and everybody pays for
+   it), the quality ladder, and the arrival preset. They used to write
+   renderer.setPixelRatio directly from five sites, and the ceiling was
+   read ONCE at boot and never again — so resize(), which fires on
+   browser zoom and on a window moving between displays of different
+   density, updated the canvas size and left the density behind.
+   Measured: devicePixelRatio 3, resize dispatched, getPixelRatio still
+   1, drawing buffer unchanged.
+
+   Naively re-reading it in resize() would have been worse than the
+   bug: it would stomp the ladder, handing a phone back the rung it
+   shed on an honest measurement every time it was rotated. So the
+   ladder and the preset now hold CAPS rather than values, the device
+   holds the ceiling, and the lowest of the three wins. A rung given up
+   still stays given up — ladderCap only ever falls — and the preset
+   restores to whatever the ladder currently allows rather than to a
+   number captured before it. */
+let dprCeiling = Math.min(window.devicePixelRatio, 2);
+let ladderCap = Infinity, presetCap = Infinity;
+const applyPixelRatio = () =>
+  renderer.setPixelRatio(Math.min(dprCeiling, ladderCap, presetCap));
+applyPixelRatio();
 renderer.shadowMap.enabled = true;
 renderer.shadowMap.type = THREE.PCFSoftShadowMap;
 renderer.outputColorSpace = THREE.SRGBColorSpace;
@@ -3807,6 +3830,12 @@ const world = new THREE.Scene();
 /* image-based lighting: glass, water and paint pick up a real environment */
 const pmrem = new THREE.PMREMGenerator(renderer);
 world.environment = pmrem.fromScene(new RoomEnvironment(), 0.06).texture;
+/* The generator is scaffolding, not the product: it holds a ping-pong
+   render target, the LOD plane geometry and three materials, and the
+   texture above outlives all of it. Disposed once the environment
+   exists, which is what three's own documented usage does — this had
+   been held for the whole session since the day IBL was added. */
+pmrem.dispose();
 world.environmentIntensity = 0.55;
 const camera = new THREE.PerspectiveCamera(46, 1, 2, 6000);
 /* Stand back further on a tall screen. Even at the widened fov, portrait
@@ -4025,13 +4054,13 @@ const RUNG_MS = 3000;            /* how long a rung gets before the next one */
 let rung = 0, rungAt = 0;
 const LADDER = [
   () => { if (ssao){ composer.removePass(ssao); ssao.dispose?.(); ssao = null; } },
-  () => renderer.setPixelRatio(1),
+  () => { ladderCap = 1; applyPixelRatio(); },
   () => { sun.shadow.mapSize.set(1536, 1536);
           sun.shadow.map?.dispose(); sun.shadow.map = null; },
   () => { renderer.shadowMap.enabled = false;
           world.traverse(o => { if (o.isMesh && o.material) [].concat(o.material)
             .forEach(m => m.needsUpdate = true); }); },
-  () => { composer.removePass(bloom); renderer.setPixelRatio(0.75); },
+  () => { composer.removePass(bloom); ladderCap = 0.75; applyPixelRatio(); },
 ];
 /* ── the arrival preset ───────────────────────────────────────────────
    The flicker, and why the ladder could never have fixed it.
@@ -4096,17 +4125,17 @@ const LADDER = [
    ratio is. It makes the frames on either side of the block cheap,
    which is worth having and is not the whole answer — see the note on
    the atrium's own load. */
-let loadPreset = false, presetDpr = 0;
+let loadPreset = false;
 function setLoadPreset(on){
   if (on === loadPreset) return;
   loadPreset = on;
   if (on){
-    /* Captured fresh each time. The ladder may have shed a pixel-ratio
-       rung since the last arrival, and restoring a number from before
-       that would hand back quality the ladder had already taken away on
-       an honest measurement. */
-    presetDpr = renderer.getPixelRatio();
-    if (presetDpr > 1) renderer.setPixelRatio(1);
+    /* A cap, not a captured number. The old shape read the current
+       ratio on the way in and wrote it back on the way out, guarded by
+       `rung < 2` so that a rung shed DURING the preset was not undone.
+       Caps make that guard unnecessary: the ladder's own cap is still
+       there underneath, so whatever it took stays taken. */
+    presetCap = 1; applyPixelRatio();
     if (ssao) ssao.enabled = false;
     bloom.enabled = false;
     renderer.shadowMap.needsUpdate = true;   /* one good map, then hold it */
@@ -4115,7 +4144,7 @@ function setLoadPreset(on){
     /* Handed back to the ladder, not forced back to full: a rung given
        up while the preset was on stays given up, because the ladder
        shed it on a measurement that was already honest. */
-    if (presetDpr > 1 && rung < 2) renderer.setPixelRatio(presetDpr);
+    presetCap = Infinity; applyPixelRatio();
     if (ssao) ssao.enabled = true;
     if (composer.passes.includes(bloom)) bloom.enabled = true;
     renderer.shadowMap.autoUpdate = true;
@@ -4125,6 +4154,10 @@ function setLoadPreset(on){
   console.info("campus: arrival preset " + (on ? "on — cheap while the cast decodes" : "off — full quality restored"));
 }
 window.__preset = () => ({ on: loadPreset, dpr: renderer.getPixelRatio(),
+                           /* the three opinions and what they resolved to, so
+                              a probe can assert the invariant rather than infer
+                              it from the one number they produce */
+                           ceiling: dprCeiling, ladderCap, presetCap,
                            ssao: !!(ssao && ssao.enabled), bloom: bloom.enabled,
                            shadowsLive: renderer.shadowMap.autoUpdate });
 const NO_LADDER = q.has("noladder");
@@ -4368,6 +4401,11 @@ function sweepPlates(now){
 
 function resize(){
   const w = stageEl.clientWidth || 800, h = stageEl.clientHeight || 600;
+  /* Browser zoom changes devicePixelRatio and fires this; so does a
+     window moving between displays. Re-read the ceiling — the ladder's
+     and the preset's caps still sit under it. */
+  dprCeiling = Math.min(window.devicePixelRatio, 2);
+  applyPixelRatio();
   renderer.setSize(w, h);
   composer.setSize(w, h);
   /* the ink samples its neighbours a texel away, so a texel has to


### PR DESCRIPTION
**Repairs 3 and 5** of `docs/REPO_INTEGRITY_AUDIT.md` §14 — PR B of the recommended sequence. Repair 4 is deliberately **not** here; see the end.

## Repair 3 — `resize()` never re-read `devicePixelRatio`

It was read once at boot and never again, while **five sites** wrote `renderer.setPixelRatio` directly. `resize()` fires on browser zoom (which changes `devicePixelRatio` in Chrome) and on a window moving between displays of different density — and it updated the canvas *size* while leaving the *density* behind.

**Measured before this change:**

```
devicePixelRatio 3, resize dispatched
getPixelRatio() still 1, drawing buffer unchanged
```

### Why the one-line fix would have been worse than the bug

Re-reading `devicePixelRatio` inside `resize()` would **stomp the quality ladder**. The ladder lowers the ratio on an honest measurement and its rungs never climb back by design; a naive re-read hands a phone its rung back every time it is rotated.

So the three opinions become explicit, and the lowest wins:

| | |
|---|---|
| `dprCeiling` | the device, capped at 2 — **re-read on every resize** |
| `ladderCap` | the quality ladder — only ever falls |
| `presetCap` | the arrival preset — 1 while the cast decodes |

```js
applyPixelRatio() = renderer.setPixelRatio(Math.min(dprCeiling, ladderCap, presetCap))
```

That also deletes the `presetDpr` capture and the `rung < 2` guard that went with it. The preset no longer restores a number captured before; it lifts its own cap, and whatever the ladder took stays taken.

### The invariant is now observable

`window.__preset()` already reported `dpr`; it now reports the three caps beside it, so the invariant can be **asserted rather than inferred**.

That mattered immediately. An earlier run of this measurement read the ratio at one moment and resized at another, saw `2` where it expected `1`, and I had no way to see that the preset had released in between — I nearly wrote it up as a failure. With the caps visible the same probe reads:

```
ok  as arrived                    dpr 1 = min(ceiling 1, ladder ∞, preset 1)
ok  devicePixelRatio 3 + resize   dpr 1 = min(ceiling 2, ladder ∞, preset 1)
ok  devicePixelRatio 1 + resize   dpr 1 = min(ceiling 1, ladder ∞, preset 1)
```

**The ceiling follows the device, 1 → 2 → 1 — and raising it does not raise the effective ratio while a cap sits under it.** That second half is the whole point: the bug is fixed and the ladder is not stomped.

## Repair 5 — the PMREM generator was never disposed

`new THREE.PMREMGenerator(renderer)` holds a ping-pong render target, the LOD plane geometry and three materials. The environment texture outlives all of it. Disposed once the environment exists — which is what three's own documented usage does. It had been held for the whole session since IBL was added.

## Not in this change — repair 4, the PMREM sigma

`fromScene(…, 0.06)` asks for 30 blur samples; r170 clips at 20 and warns twice per boot. I worked out the exact ceiling from the vendored source:

```
pixels = _sizeLods[0] - 1 = 255
samples = 1 + floor(3 × sigma × 2 × pixels / π) ≤ 20   →   sigma ≤ ~0.041
```

So `0.04` is the largest value r170 will honour. **But it is not a free change:** the clip truncates a *wide* kernel (sigmaPixels 9.67, 20 taps), where `0.04` would use a *complete narrower* one (sigmaPixels 6.49, 20 taps). The environment map genuinely changes — a slightly crisper IBL on glass, water and paint at `environmentIntensity 0.55`.

That is a decision about how the campus **looks**, not a lifecycle repair, and it does not belong in a PR titled like this one. Flagged for a call rather than made quietly.

## Scope

`index.html` only. No version bump — nothing under `assets/` changed. Independent of #120, #121 and #124.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_