### PR TITLE
The environment blur asked for 30 samples and got 20

### DIFF
--- a/index.html
+++ b/index.html
@@ -3839,7 +3839,35 @@ stageEl.appendChild(labelRenderer.domElement);
 const world = new THREE.Scene();
 /* image-based lighting: glass, water and paint pick up a real environment */
 const pmrem = new THREE.PMREMGenerator(renderer);
-world.environment = pmrem.fromScene(new RoomEnvironment(), 0.06).texture;
+/* 0.04, not 0.06, and the number is derived rather than tuned. r170's
+   PMREMGenerator blurs with at most MAX_SAMPLES = 20 taps:
+
+     pixels   = _sizeLods[0] - 1 = 255
+     samples  = 1 + floor(3 × sigma × 2 × pixels / π)
+
+   At 0.06 that asks for 30, so three clipped it to 20 and said so —
+   twice, every boot, in production. The kernel was therefore a WIDE
+   gaussian truncated at 20 taps rather than the blur the number
+   claimed. 0.041 is the largest sigma this generator will honour, so
+   0.04 buys a complete kernel with margin, and the code now describes
+   what the GPU actually does.
+
+   It IS a narrower blur, so it was measured rather than assumed —
+   two spheres lit by the environment and nothing else, at the
+   campus's own environmentIntensity of 0.55:
+
+     near-mirror (metal, roughness 0.05), the worst case
+       mean |Δ| 0.56/255 · peak 118 · 3.5% of pixels moved >2/255
+       mean brightness 26.9 → 26.5
+     stone as this campus wears it (roughness 0.75)
+       mean |Δ| 0.16/255 · peak 5 · 1.7% of pixels moved >2/255
+       mean brightness 22.7 → 22.6
+
+   The peak of 118 is a specular highlight edge on a near-mirror
+   moving by a pixel — the sharpest thing an environment can do. On
+   the surfaces the campus is actually built from it is a peak of 5
+   and no brightness shift. */
+world.environment = pmrem.fromScene(new RoomEnvironment(), 0.04).texture;
 /* The generator is scaffolding, not the product: it holds a ping-pong
    render target, the LOD plane geometry and three materials, and the
    texture above outlives all of it. Disposed once the environment


### PR DESCRIPTION
**Repair 4** of `docs/REPO_INTEGRITY_AUDIT.md` §14 — the last of the confirmed defects. One line of code, held back from #125 on purpose because unlike a `dispose()` it changes how the campus **looks**.

```
sigmaRadians, 0.06, is too large and will clip,
as it requested 30 samples when the maximum is set to 20
```

Twice, every boot, in production.

## The arithmetic

r170's `PMREMGenerator` blurs with at most `MAX_SAMPLES = 20` taps:

```
pixels  = _sizeLods[0] - 1 = 255
samples = 1 + floor(3 × sigma × 2 × pixels / π)
```

At `0.06` that asks for **30**. Three clipped it and carried on — so what the GPU produced was a **wide gaussian truncated at 20 taps**, not the blur the number claimed. `0.041` is the largest sigma this generator will honour; `0.04` buys a complete kernel with margin, and the code now describes what actually happens.

**Warnings: 2 → 0.**

## Measured, not argued about

A screenshot of the quad moves for a dozen reasons — crowd, clock, streaming — so it cannot answer *"did the blur change"*. Instead: two spheres in an empty scene with **no lights at all**, lit by the environment and nothing else, at the campus's own `environmentIntensity` of 0.55.

| | mean \|Δ\| | peak | pixels >2/255 | brightness |
|---|---|---|---|---|
| **near-mirror** (metal, roughness 0.05) | 0.56/255 | 118 | 3.5% | 26.9 → 26.5 |
| **stone as the campus wears it** (roughness 0.75) | 0.16/255 | **5** | 1.7% | 22.7 → 22.6 |

A near-mirror is the most sensitive thing an environment map can light, which is exactly why it is here: the peak of **118** is a specular highlight edge moving by a pixel. On the surfaces the campus is actually built from it is a peak of **5** and no brightness shift.

## Two things I got wrong on the way, both corrected

1. **The first measurement used only the mirror.** That is the worst case and reporting it alone would overstate what a visitor sees — a 9.3%-of-pixels-changed figure that says nothing about stone. The rough sphere is what makes the number honest.
2. **The first version of the code comment said `mean |Δ| 0.32/255`** — a number I wrote *before the measurement ran*, and which was never true. The real figure is 0.56. A fabricated number in a comment explaining a measurement is worse than no comment at all.

## Scope

`index.html`, one line changed plus the note deriving it. No version bump — nothing under `assets/` changed.

## The top ten, complete but for the two structural ones

| | repair | |
|---|---|---|
| ✅ | 1 · 2 font tokens + `var()` gate | #124 |
| ✅ | 3 · 5 DPR ceiling + PMREM dispose | #125 |
| ✅ | **4 PMREM sigma** | **this PR** |
| ✅ | 7 · 8 · 9 | #126 |
| ⬜ | 6 draw-call ceiling in `check-frame` | PR D |
| ⬜ | 10 merge static scenery | PR E, gated on D |

That is every confirmed defect in the audit closed. What remains is the one **P1** — ~1,239 draw calls with no ladder rung able to lower them — and it is deliberately last, because PR E should only happen if PR D's number says it is worth it.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_