### PR TITLE
A ceiling on the draw calls, and a settled number to judge it against

### DIFF
--- a/tools/check-frame.mjs
+++ b/tools/check-frame.mjs
@@ -60,6 +60,40 @@ await page.goto(`http://localhost:${PORT}/index.html?crowd`,
 await page.waitForFunction(() => window.__crowd && window.__crowd().ready &&
   window.__students.length > 0, null, { timeout: 600000 });
 await page.evaluate(() => window.__crowdFill());
+
+/* ── SETTLE, and prove it settled ─────────────────────────────────────
+   The census below reads renderer.info for the LAST FRAME, and until
+   this was added it read whatever frame happened to be current. The
+   campus streams in — detailPass, the crowd ramp, the late landmark
+   wave — so that number climbs for minutes after "ready". The audit
+   that asked for this check sampled 711, then 723, then 765, and only
+   then found the true figure was 1239: three of those four were the
+   scene still arriving, and not one of them was wrong at the moment it
+   was taken.
+
+   So take the median of a short burst, twice, and trust the number only
+   when two windows agree. A count that never settles is reported as
+   such rather than averaged into something tidy. */
+const burst = () => page.evaluate(() => new Promise((done) => {
+  const r = window.__app.renderer, c = [];
+  let n = 0;
+  const tick = () => { c.push(r.info.render.calls);
+    if (++n < 12) requestAnimationFrame(tick);
+    else { c.sort((a, b) => a - b); done(c[c.length >> 1]); } };
+  requestAnimationFrame(tick);
+}));
+let settled = false, prev = -1;
+for (let i = 0; i < 10; i++){
+  await page.waitForTimeout(12000);
+  const now = await burst();
+  if (prev >= 0) console.log(`   settling... median draw calls ${now} (was ${prev})`);
+  if (prev >= 0 && Math.abs(now - prev) <= 2){ settled = true; prev = now; break; }
+  prev = now;
+}
+const drawCalls = prev;
+console.log(settled
+  ? `   settled at ${drawCalls} draw calls\n`
+  : `   NEVER SETTLED - the last two windows disagreed; ${drawCalls} is a moving number\n`);
 /* ...and wait for the OUTER WORLD, which is the whole reason a previous
    run could not see the residence hall. Landmarks are fetched after the
    campus reports ready, deliberately and one at a time, so a measurement
@@ -225,7 +259,16 @@ const r = await page.evaluate(() => {
 const n = (x) => (x || 0).toLocaleString();
 const m = (x) => ((x || 0) / 1e6).toFixed(2) + "M";
 console.log(`renderer   ${r.size} at pixelRatio ${r.pixelRatio}`);
-console.log(`draw calls ${n(r.render.calls)}   triangles ${m(r.render.tris)}   (three.js own count for the last frame)`);
+/* Two numbers, because they disagree and the difference is the point.
+   The settled median is what the campus costs in a steady frame. The
+   raw figure beneath it is renderer.info for whatever frame happened to
+   be current when the census ran — the reading this check printed on
+   its own before settling was added, and it came out 252 higher on the
+   run that introduced the ceiling. Judge regressions on the settled
+   one; the raw is kept because a large gap between them is itself worth
+   seeing. */
+console.log(`draw calls ${n(drawCalls)}   triangles ${m(r.render.tris)}   (settled median)`);
+console.log(`           ${n(r.render.calls)} on the single frame the census read`);
 console.log(`programs   ${r.programs}   materials ${r.materials}   textures ${r.textures} (~${r.texMB}MB decoded)`);
 console.log(`lights     ${r.lights}, of which ${r.shadowLights} cast shadows (${r.shadowMap})`);
 console.log(`shadows    ${n(r.shadowDraws)} casters, ${m(r.shadowTris)} triangles re-drawn per shadow pass`);
@@ -248,6 +291,43 @@ for (const [k, v] of Object.entries(r.byOrigin || {}))
 console.log("\ntexture memory by resolution — the decoded footprint, not the file size");
 for (const [dim, mb] of r.byTex)
   console.log(`   ${String(mb).padStart(7)}MB  ${dim}`);
+
+/* == THE CEILING ======================================================
+   Draw calls are the one number here that is the same on every GPU, and
+   on a phone they are usually what runs out first. This campus's own
+   field note, from a real Adreno during the arrival-flicker
+   investigation, reads "1289 draws, 7.13M triangles".
+
+   The quality ladder cannot help with this. Its five rungs trade SSAO,
+   pixel ratio, shadow-map size, shadows and bloom - fill rate and
+   post-processing, every one. Not a single rung removes a draw call, so
+   a submit-bound device gets no relief at any rung, and rungs never
+   climb back. That makes this a hard floor on what the campus costs,
+   which is exactly the kind of number that should not be allowed to
+   drift quietly upward.
+
+   DRAW_CEILING is MEASURED, not chosen: the figure this check reported
+   on a settled full-crowd campus when the limit was introduced, plus
+   room for honest variation. Raise it deliberately, with a note saying
+   what was added and why it was worth it. That is the whole point of
+   having it. */
+const DRAW_CEILING = 1320;
+console.log("");
+if (!settled){
+  console.log(` FAIL  draw calls never settled - ${drawCalls} is a moving number, ` +
+              `so no ceiling can be judged against it`);
+  await browser.close(); srv.close(); process.exit(1);
+}
+if (drawCalls > DRAW_CEILING){
+  console.log(` FAIL  ${drawCalls} draw calls, over the ceiling of ${DRAW_CEILING}\n` +
+    `       Nothing in the quality ladder can lower this - every rung trades fill\n` +
+    `       rate, not geometry - so it is a floor on what the campus costs on a\n` +
+    `       phone. Merge static scenery by material, hide distant props, or raise\n` +
+    `       the ceiling ON PURPOSE with a note saying what was added.`);
+  await browser.close(); srv.close(); process.exit(1);
+}
+console.log(`  ok   ${drawCalls} draw calls, within the ceiling of ${DRAW_CEILING}` +
+            ` (${DRAW_CEILING - drawCalls} to spare)`);
 
 await browser.close();
 srv.close();


### PR DESCRIPTION
**Repair 6** of `docs/REPO_INTEGRITY_AUDIT.md` §14 — PR D, and the gate the one **P1** needs before anything is done about it. `tools/check-frame.mjs` only.

## The check was reading a moving number

`check-frame` read `renderer.info` for whatever frame happened to be current. The campus streams in for *minutes* after "ready" — `detailPass`, the crowd ramp, the late landmark wave — so that figure climbs the whole time. Every reading is correct at the moment it is taken and useless afterwards.

The audit that asked for this sampled **711**, then **723**, then **765**, and only then found the settled figure was **1239**. Three of those four were the scene still arriving.

So it settles first: the median of a twelve-frame burst, twice, trusted only when two windows agree within 2. **A count that never settles is now a failure**, not something averaged into looking tidy — no ceiling can be judged against a moving number.

## That immediately found something

On the run that introduced the limit:

```
settling... median draw calls 1239 (was 1197)
settling... median draw calls 1239 (was 1239)
settled at 1239 draw calls

draw calls 1,491   ← what the old single-frame read reported
```

**252 apart.** The report now prints both, because the gap is itself worth seeing: the settled median is what a steady frame costs, and the raw figure sits beneath it, labelled as the frame the census happened to catch.

## The ceiling

`DRAW_CEILING = 1320` — the measured **1239** plus room for honest variation between runs. **Measured, not chosen.**

It exists because draw calls are the one number in this check that is the same on every GPU, and because **no rung of the quality ladder can lower it.** The five rungs trade SSAO, pixel ratio, shadow-map size, shadows and bloom — fill rate and post-processing, every one. A submit-bound phone gets no relief at any rung, and rungs never climb back. This repository's own field note from a real Adreno reads *"1289 draws, 7.13M triangles"*.

That makes this a hard floor on what the campus costs, which is exactly the kind of number that should not drift quietly upward.

## Both paths exercised

| ceiling | result |
|---|---|
| `999999` | `ok   1239 draw calls, within the ceiling` |
| `1200` | `FAIL 1239 draw calls, over the ceiling of 1200` — **exit 1** |

The failure message says what to do — merge static scenery, hide distant props, or raise the ceiling **on purpose** with a note saying what was added.

## Deliberately not wired into CI

The run takes roughly **ten minutes** on a software rasterizer, which is `smoke`-job territory. After a day spent removing two flaky gates (#122's vacuous a11y check, #123's non-idempotent clock loop), I would rather a tenth CI job be added **on purpose** than as a side effect of a repair.

The gate lives in the tool, so anyone who runs it gets it. Wiring it to a workflow is one line in `smoke.yml` and is your call — `tools/README.md` currently classifies `check-frame` as "run by hand, and worth running", and adding it to CI changes that classification.

## What this unblocks

**PR E** — repair 10, merging static scenery by material. The audit is explicit that it should be **abandoned if the numbers do not move**: 81 materials are used by exactly one mesh and only 5 geometries are shared, so there is headroom in principle, but merging costs frustum granularity — and §9.1 showed culling already removes only 7 of 527 visible meshes, so there is little to lose *and* little proof it will help until measured.

This PR is the scale that measurement gets weighed on.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_