### PR TITLE
Give the performance gate a workload, and withdraw the one that had none

### DIFF
--- a/docs/REPO_INTEGRITY_AUDIT.md
+++ b/docs/REPO_INTEGRITY_AUDIT.md
@@ -585,7 +585,22 @@ repository has already been swept; this pass found no second layer.
 > the ladder's own definition, not from a sample.
 >
 > The replacement is `tools/check-perf.mjs`, which specifies a workload
-> instead of waiting for the scene to hold still. The ceiling that used
+> instead of waiting for the scene to hold still.
+>
+> **The replacement's first baseline, for contrast.** One launch of the
+> deterministic workload — fixed camera, fixed viewport and pixel ratio,
+> ladder held, crowd filled and frozen, 30 warm frames discarded, 90
+> sampled:
+>
+> ```
+> min 1482 · p50 1482 · p90 1483 · p95 1483 · max 1483
+> mean 1482.4 · stddev 0.5
+> ```
+>
+> **Standard deviation 0.5 — the count moved by one across ninety
+> frames.** The same campus under the retracted method produced 711,
+> 723, 765, 803, 1239, 1243, 1491 and 1609. That is the difference
+> between a number and a measurement. The ceiling that used
 > to live in `check-frame` has been withdrawn rather than left in place:
 > a gate with no stable meaning turns a broken instrument into policy,
 > and a green build would have claimed the campus stayed inside an

--- a/docs/REPO_INTEGRITY_AUDIT.md
+++ b/docs/REPO_INTEGRITY_AUDIT.md
@@ -560,7 +560,37 @@ repository has already been swept; this pass found no second layer.
 
 ## 9. Performance
 
-### 9.1 P1 · CONFIRMED · ~1,239 draw calls, and no rung of the ladder lowers it
+### 9.1 P1 · RETRACTED AS A MEASUREMENT · ~1,239 draw calls, and no rung of the ladder lowers it
+
+> **RETRACTION — the numbers in this section are not valid comparative
+> measurements.**
+>
+> Previous draw-call values and the reported 22.9% delta were generated
+> from measurements taken at non-equivalent points in a continuously
+> changing scene. They are retained as historical observations but are
+> not valid comparative performance measurements.
+>
+> The method waited for two sampling windows to agree and treated that
+> as "settled". This campus never settles: the crowd churns by design,
+> bodies walking into buildings and out again for the whole session.
+> Measured, the same check read **1243** where the finished campus reads
+> **1609**, and `arrivalState` already reported "not arriving" at 1243.
+> Every figure below — 711, 723, 765, 1239, 1491 — is one arbitrary
+> moment in a moving scene, and so is the 1609.
+>
+> **What survives this retraction** is the structural claim, which does
+> not depend on the number: frustum culling removes almost nothing from
+> the default viewpoint, and **no rung of the five-rung quality ladder
+> removes a draw call** — every rung trades fill rate. That is read from
+> the ladder's own definition, not from a sample.
+>
+> The replacement is `tools/check-perf.mjs`, which specifies a workload
+> instead of waiting for the scene to hold still. The ceiling that used
+> to live in `check-frame` has been withdrawn rather than left in place:
+> a gate with no stable meaning turns a broken instrument into policy,
+> and a green build would have claimed the campus stayed inside an
+> envelope nobody had defined.
+
 
 **Measured**, desktop 1280×800, day, after proving the scene settled
 (median draw calls stable across two 15-second windows):
@@ -834,7 +864,7 @@ are judgement calls for the owner, not repairs.
 | **most serious Three.js defect** | §4.3 — `resize()` never re-reads `devicePixelRatio`; measured DPR 3 with the renderer still at 1 |
 | **most serious CSS/DOM defect** | §7.1 — `--font-serif` declared nowhere; `.jpanel h3` measured rendering in Georgia beside a loaded Cormorant Garamond |
 | **worst silent failure** | §7.1, the same one. `var(--x, fallback)` turns a missing token into a design decision |
-| **largest performance waste** | §9.1 — ~1,239 settled draw calls with no ladder rung able to lower them; corroborated at 1,289 on a real Adreno by the repo's own field note |
+| **largest performance waste** | §9.1 — no ladder rung can lower a draw call, so the submit count is a floor on what the campus costs. **The figures are retracted as measurements** (see §9.1): they were taken at non-equivalent points in a scene that never settles. The structural claim stands; the numbers await `tools/check-perf.mjs` |
 | **highest-value cleanup** | §12's `var()` gate — 15 lines that close the only unowned contract in §2 |
 
 **Top five repairs:** declare the two font tokens · gate `var()`

--- a/docs/REPO_INTEGRITY_AUDIT.md
+++ b/docs/REPO_INTEGRITY_AUDIT.md
@@ -599,12 +599,38 @@ repository has already been swept; this pass found no second layer.
 >
 > **Standard deviation 0.5 — the count moved by one across ninety
 > frames.** The same campus under the retracted method produced 711,
-> 723, 765, 803, 1239, 1243, 1491 and 1609. That is the difference
-> between a number and a measurement. The ceiling that used
-> to live in `check-frame` has been withdrawn rather than left in place:
-> a gate with no stable meaning turns a broken instrument into policy,
-> and a green build would have claimed the campus stayed inside an
-> envelope nobody had defined.
+> 723, 765, 803, 1239, 1243, 1491 and 1609.
+>
+> **Read that the right way round.** The old spread was not noise in a
+> measurement of one thing. It was a sequence of measurements of
+> *different things* — a campus with 700 draw calls' worth of people in
+> it is not the same workload as a campus with 1,600, and the old method
+> sampled whichever one happened to exist when two windows agreed. The
+> story is not "our performance numbers varied a lot." It is **"the
+> previous instrument was measuring different workloads."** Hold the
+> workload still and the count is stable to within a single draw call,
+> which is what the 0.5 proves: the variance was never in the renderer,
+> it was in what we pointed the instrument at.
+>
+> The ceiling that used to live in `check-frame` has been withdrawn
+> rather than left in place: a gate with no stable meaning turns a
+> broken instrument into policy, and a green build would have claimed
+> the campus stayed inside an envelope nobody had defined.
+>
+> **Before any ceiling is set again**, the calibration run must carry
+> its own provenance, because a workload specification only fixes half
+> of a measurement — the other half is the machine. `check-perf` now
+> records, in the run record and in `--calibrate` output: the GPU and
+> driver string, **whether hardware acceleration was actually active**,
+> browser and version, OS, CPU count and memory, and the CI runner image
+> where CI sets it. The accelerated flag is the one that decides
+> transferability: the baseline above was produced under SwiftShader
+> (`ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device …))`,
+> `accelerated: false`), and a ceiling derived from a software
+> rasterizer does not describe a GPU runner however identical the
+> workload was. `--calibrate` refuses to recommend a number when
+> acceleration was off, and the commit that eventually sets
+> `P95_CEILING` is required to paste this block beside it.
 
 
 **Measured**, desktop 1280×800, day, after proving the scene settled

--- a/index.html
+++ b/index.html
@@ -4196,6 +4196,11 @@ window.__preset = () => ({ on: loadPreset, dpr: renderer.getPixelRatio(),
                               a probe can assert the invariant rather than infer
                               it from the one number they produce */
                            ceiling: dprCeiling, ladderCap, presetCap,
+                           /* which rung the ladder has shed to, and why it
+                              stopped there — a benchmark reading is only
+                              reproducible if the quality it was taken at is
+                              recorded beside it */
+                           rung, rungWhy: LADDER_WHY,
                            ssao: !!(ssao && ssao.enabled), bloom: bloom.enabled,
                            shadowsLive: renderer.shadowMap.autoUpdate });
 const NO_LADDER = q.has("noladder");

--- a/index.html
+++ b/index.html
@@ -3906,6 +3906,14 @@ const q = new URLSearchParams(location.search);
 const glInfo = (renderer.getContext().getParameter(
   renderer.getContext().getExtension("WEBGL_debug_renderer_info")?.UNMASKED_RENDERER_WEBGL || 7937) || "") + "";
 const softGL = /swiftshader|llvmpipe|software/i.test(glInfo);
+/* Published because a performance number is only reproducible if the
+   machine that produced it is recorded beside it. The run record can
+   carry the commit, the profile and the pose; it cannot carry the
+   hardware unless the page says what it is running on — and "was
+   hardware acceleration actually active" is the single field that
+   decides whether a ceiling calibrated somewhere describes here. */
+window.__gpu = () => ({ info: glInfo, software: softGL,
+                        accelerated: !softGL, ua: navigator.userAgent });
 const composer = new EffectComposer(renderer);
 composer.addPass(new RenderPass(world, camera));
 let ssao = null;

--- a/index.html
+++ b/index.html
@@ -4199,6 +4199,26 @@ window.__preset = () => ({ on: loadPreset, dpr: renderer.getPixelRatio(),
                            ssao: !!(ssao && ssao.enabled), bloom: bloom.enabled,
                            shadowsLive: renderer.shadowMap.autoUpdate });
 const NO_LADDER = q.has("noladder");
+/* ?bench — A WORKLOAD, NOT A RENDERING MODE.
+   A performance gate needs a specification of what is being measured.
+   "Wait until the scene settles" was never one for this campus: the
+   crowd churns by design, bodies walking into buildings and out again
+   for the whole session, so there is no moment when the draw count
+   stops moving. A check that waited for two readings to agree got 1243
+   where the finished campus reads 1609, and the ceiling built on that
+   number gated merges for a day.
+
+   So this freezes the things that must be CONTROLLED and changes
+   nothing about how a frame is DRAWN — the same passes, the same
+   materials, the same shadow map. What it holds still: the crowd's
+   motion, the camera, the quality ladder, and the clock. What it does
+   not touch: anything the renderer does with what is in front of it.
+   A number measured here is comparable to another number measured
+   here, which is the only property a regression gate actually needs.
+
+   The POSE is deliberately not set here. The tool that drives the
+   measurement owns the workload spec; the page only owns the freeze. */
+const BENCH = q.has("bench");
 /* WHY the ladder is not shedding, in words, for the frame after this
    one to report. The panel could always say which rung the campus was
    on and never why it was still on it — and "why" is the whole question
@@ -4243,6 +4263,10 @@ function stepQuality(now, fpsNow){
      whole duration too. */
   const arr = arrivalState(now);
   if (!NO_LADDER) setLoadPreset(arr.arriving);
+  /* the preset still lifts when the assets are in — measuring the
+     campus mid-arrival is the whole thing being fixed — but no rung is
+     ever shed, so quality cannot move under a sample */
+  if (BENCH){ LADDER_WHY = "benchmark — the ladder is held"; return; }
   if (NO_LADDER || rung >= LADDER.length){ LADDER_WHY = rung >= LADDER.length ? "nothing left to give up" : "disabled"; return; }
   /* Not on a software rasterizer. Its frame rate is a fact about a CPU
      drawing pixels one at a time and says nothing about any GPU, so
@@ -12739,13 +12763,13 @@ renderer.setAnimationLoop(() => {
      two things that react to a slow machine, rather than two averages
      that can disagree about what the machine is doing. */
   stepQuality(now, crowdFps);
-  stepStudents(dt, now);
+  if (!BENCH) stepStudents(dt, now);   /* frozen where they stand */
   if (walker.on) walkUpdate(dt);
-  else { stepFlight(now); controls.update(); }
-  if (autoCycle && !interiorView){
+  else if (!BENCH) { stepFlight(now); controls.update(); }
+  if (autoCycle && !interiorView && !BENCH){
     cycleT += dt / 180;                /* a full day in three minutes */
     setTimeOfDay(cycleT);
-  } else if (liveClock && !interiorView && now - lastClock > 20000){
+  } else if (liveClock && !interiorView && !BENCH && now - lastClock > 20000){
     /* the real sky moves slowly; a check every 20s is plenty and keeps
        this off the per-frame path */
     lastClock = now;

--- a/tools/check-frame.mjs
+++ b/tools/check-frame.mjs
@@ -292,42 +292,53 @@ console.log("\ntexture memory by resolution — the decoded footprint, not the f
 for (const [dim, mb] of r.byTex)
   console.log(`   ${String(mb).padStart(7)}MB  ${dim}`);
 
-/* == THE CEILING ======================================================
-   Draw calls are the one number here that is the same on every GPU, and
-   on a phone they are usually what runs out first. This campus's own
-   field note, from a real Adreno during the arrival-flicker
-   investigation, reads "1289 draws, 7.13M triangles".
+/* == THE CEILING, WITHDRAWN =========================================
+   This asserted `drawCalls <= 1320` and it is switched off, because the
+   number it compared and the number it compared it AGAINST were both
+   taken at a moment nobody had defined.
 
-   The quality ladder cannot help with this. Its five rungs trade SSAO,
-   pixel ratio, shadow-map size, shadows and bloom - fill rate and
-   post-processing, every one. Not a single rung removes a draw call, so
-   a submit-bound device gets no relief at any rung, and rungs never
-   climb back. That makes this a hard floor on what the campus costs,
-   which is exactly the kind of number that should not be allowed to
-   drift quietly upward.
+   The settle above stops when two twelve-second windows agree within 2.
+   That was believed to mean "the campus has finished arriving". It does
+   not, and the measurement that established the ceiling is the one that
+   disproves it:
 
-   DRAW_CEILING is MEASURED, not chosen: the figure this check reported
-   on a settled full-crowd campus when the limit was introduced, plus
-   room for honest variation. Raise it deliberately, with a note saying
-   what was added and why it was worth it. That is the whole point of
-   having it. */
-const DRAW_CEILING = 1320;
+     check-frame's own rule        1243 draws   (arrivalState: not arriving)
+     kept waiting                  1609 draws
+
+   +366. And the obvious repair — wait for __preset().on === false —
+   fails too: `arriving` was ALREADY false at 1243. arrivalState tracks
+   the asset log, and this campus keeps changing after the last asset
+   lands because the crowd churns by design: bodies walk into buildings
+   and out again for the whole session. There is no moment when the
+   scene stops changing, so two agreeing windows is luck, not
+   convergence.
+
+   1320 was therefore derived from a premature 1243. The gate was
+   self-consistently wrong — it measured early, compared an early number
+   to a ceiling built from an early number, and passed. A run that
+   happened to wait longer would read 1609 and fail on unchanged code.
+
+   A gate with no stable meaning is worse than no gate: a green build
+   would claim the campus stayed inside an envelope that was never
+   defined. So the assertion is withdrawn rather than left in place, and
+   what is printed below is a DIAGNOSTIC — a number to look at, not a
+   number to merge against.
+
+   The replacement is tools/check-perf.mjs, which specifies the workload
+   instead of waiting for the scene to hold still: fixed camera, fixed
+   viewport and pixel ratio, ladder held, crowd filled and frozen, warm
+   N frames, sample M, report a distribution. Re-baseline from repeated
+   deterministic runs on unchanged main before anything gates again. */
 console.log("");
 if (!settled){
-  console.log(` FAIL  draw calls never settled - ${drawCalls} is a moving number, ` +
-              `so no ceiling can be judged against it`);
-  await browser.close(); srv.close(); process.exit(1);
+  console.log(`  ..   draw calls did not settle — last reading ${drawCalls}. Not a` +
+              ` failure: this scene never stops changing, which is why the ceiling` +
+              ` that used to live here was withdrawn.`);
+} else {
+  console.log(`  ..   ${drawCalls} draw calls at the moment two windows agreed.` +
+              ` DIAGNOSTIC ONLY — see the note above, and tools/check-perf.mjs for` +
+              ` the measurement that has a defined workload.`);
 }
-if (drawCalls > DRAW_CEILING){
-  console.log(` FAIL  ${drawCalls} draw calls, over the ceiling of ${DRAW_CEILING}\n` +
-    `       Nothing in the quality ladder can lower this - every rung trades fill\n` +
-    `       rate, not geometry - so it is a floor on what the campus costs on a\n` +
-    `       phone. Merge static scenery by material, hide distant props, or raise\n` +
-    `       the ceiling ON PURPOSE with a note saying what was added.`);
-  await browser.close(); srv.close(); process.exit(1);
-}
-console.log(`  ok   ${drawCalls} draw calls, within the ceiling of ${DRAW_CEILING}` +
-            ` (${DRAW_CEILING - drawCalls} to spare)`);
 
 await browser.close();
 srv.close();

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -56,10 +56,21 @@
  * five independent browsers and prints the spread across them; the
  * ceiling belongs above the highest p95 seen across several such
  * launches, with the reason written down.
+ *
+ * PROVENANCE. The workload above is half of a measurement; the machine
+ * is the other half. Every record carries `environment` — GPU and
+ * driver string, WHETHER HARDWARE ACCELERATION WAS ACTUALLY ACTIVE,
+ * browser and version, OS, CPUs, memory, and the CI runner image where
+ * CI provides it. The accelerated flag is the one that decides whether
+ * a ceiling transfers: SwiftShader and a real GPU are not the same
+ * measurement however identical the workload was, so --calibrate
+ * refuses to recommend a number when acceleration was off, and the
+ * commit that sets P95_CEILING must paste this block beside it.
  */
 import { serve, launch, reporter } from "./_harness.mjs";
 import { execSync } from "node:child_process";
 import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
+import { platform, release, arch, cpus, totalmem } from "node:os";
 
 const argv = process.argv.slice(2);
 const LIVE  = argv.includes("--live");
@@ -222,8 +233,10 @@ async function measure(origin, browser, i){
 
   const elapsedMs = Date.now() - t0;
   const env = await page.evaluate(() => {
+    const g = window.__gpu ? window.__gpu() : {};
     const p = window.__preset();
     return { dpr: p.dpr, rung: p.rung, rungWhy: p.rungWhy, presetOn: p.on,
+             gpu: g.info ?? null, accelerated: g.accelerated ?? null, ua: g.ua ?? null,
              crowd: window.__crowd().n, people: window.__students.length,
              build: (document.documentElement.innerHTML.match(/const BUILD = "([^"]+)"/) || [,"?"])[1] };
   });
@@ -257,8 +270,27 @@ note(`p95 across ${RUNS} launch(es): ${p95s.join(", ")}  ·  spread ${spread}`);
    one; it is REPRODUCIBLE only if everything that could have changed it
    is written down next to it. This block is that, and it is emitted as
    JSON so a run can be diffed against a run rather than remembered. */
+/* THE MACHINE, not just the workload. A ceiling calibrated on one class
+   of runner does not describe another, and the single field that
+   decides it is whether hardware acceleration was actually ACTIVE — a
+   number from SwiftShader and a number from a real GPU are not the same
+   measurement however identical the workload was. Runner image and OS
+   come from the environment where CI sets them. */
+const environment = {
+  gpu: all[0]?.gpu ?? null,
+  hardwareAccelerated: all[0]?.accelerated ?? null,
+  browser: `${browser.browserType().name()} ${browser.version()}`,
+  userAgent: all[0]?.ua ?? null,
+  os: `${platform()} ${release()} ${arch()}`,
+  cpus: cpus().length,
+  totalMemGB: +(totalmem() / 1073741824).toFixed(1),
+  runnerImage: process.env.ImageOS || process.env.RUNNER_IMAGE || null,
+  runnerOS: process.env.RUNNER_OS || null,
+  ci: process.env.CI === "true" || !!process.env.GITHUB_ACTIONS,
+};
 const record = {
   benchVersion: BENCH_VERSION,
+  environment,
   profile: PROFILE,
   profileValidated: PROFILES[PROFILE].validated,
   workload: LIVE ? "live" : "deterministic",
@@ -306,13 +338,23 @@ if (CALIBRATE){
   if (!validProfile) console.log(`\n  PROFILE "${PROFILE}" IS UNVALIDATED — calibrate on "full", or first` +
                                  `\n  show that this profile's p95 tracks it.`);
   if (LIVE) console.log(`\n  LIVE WORKLOAD — cannot calibrate a gate from a stochastic run.`);
+  console.log(`  measured on         ${environment.gpu || "unknown GPU"}`);
+  console.log(`  hardware accelerated ${environment.hardwareAccelerated}` +
+              (environment.hardwareAccelerated === false
+                 ? "   *** a ceiling from a software rasterizer does not describe a GPU runner ***" : ""));
+  console.log(`  browser / os        ${environment.browser} · ${environment.os}` +
+              (environment.runnerImage ? ` · image ${environment.runnerImage}` : ""));
   if (enough && stable && validProfile && !LIVE){
     const rec = Math.ceil(worst * (1 + HEADROOM));
     console.log(`\n  RECOMMENDED P95_CEILING = ${rec}   (worst ${worst} + ${(HEADROOM*100).toFixed(0)}%)`);
-    console.log(`  Set it by hand, in a commit that says which machine this ran on —`);
-    console.log(`  the record carries the commit and the profile but cannot carry the`);
-    console.log(`  hardware, and a ceiling from one class of runner does not describe`);
-    console.log(`  another.`);
+    console.log(`  Set it by hand, in a commit that carries the provenance printed`);
+    console.log(`  above: GPU and driver string, whether acceleration was ACTIVE,`);
+    console.log(`  browser and version, runner image and OS. The record block holds`);
+    console.log(`  all of it — paste it into the commit that sets the number.`);
+    if (environment.hardwareAccelerated === false){
+      console.log(`\n  BUT NOT FROM THIS RUN: acceleration was not active. This number`);
+      console.log(`  describes a software rasterizer and must not gate a GPU runner.`);
+    }
   } else {
     console.log(`\n  NO RECOMMENDATION. The conditions above are the whole point;`);
     console.log(`  a number produced without them is how the last ceiling happened.`);

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -58,18 +58,41 @@
  * launches, with the reason written down.
  */
 import { serve, launch, reporter } from "./_harness.mjs";
+import { execSync } from "node:child_process";
+import { readFileSync, writeFileSync, mkdirSync } from "node:fs";
 
 const argv = process.argv.slice(2);
 const LIVE  = argv.includes("--live");
 const RUNS  = Math.max(1, +(argv[argv.indexOf("--runs") + 1] || 1) || 1);
-const WARMUP = 120;
-const SAMPLE = 300;
+const OUT   = argv.includes("--out") ? argv[argv.indexOf("--out") + 1] : null;
+
+/* BENCH_VERSION changes whenever anything about the workload changes —
+   the pose, the frame counts, what ?bench freezes. Numbers from
+   different versions are not comparable, and recording it is what makes
+   that checkable rather than remembered. */
+const BENCH_VERSION = 1;
+
+/* Two profiles, because the full one is not free. Measured on a
+   software rasterizer with a full crowd, 120 warm + 300 sampled frames
+   ran past FORTY MINUTES — trivial on a GPU, punishing headless. So the
+   full profile is for nightly and release validation, and a shorter one
+   exists for per-PR use.
+   THE SHORT PROFILE IS NOT YET VALIDATED: nobody has shown its p95
+   tracks the full profile's. Until somebody does, it reports and does
+   not gate, the same as the ceiling it would feed. */
+const PROFILES = {
+  full: { warmup: 120, sample: 300, validated: true  },
+  ci:   { warmup:  30, sample:  90, validated: false },
+};
+const PROFILE = argv.includes("--profile") ? argv[argv.indexOf("--profile") + 1] : "full";
+if (!PROFILES[PROFILE]){ console.log(`unknown profile "${PROFILE}" — try full or ci`); process.exit(1); }
+const { warmup: WARMUP, sample: SAMPLE } = PROFILES[PROFILE];
 
 /* The pose. It lives HERE, in the tool, because the camera position is
    part of the workload specification and not part of the campus. The
    quad from the north-west, high enough to hold the whole academic
    range — the view a visitor actually arrives on. */
-const POSE = { pos: [-420, 300, 420], look: [0, 0, 0] };
+const POSE = { v: 1, pos: [-420, 300, 420], look: [0, 0, 0] };
 
 /* THE CEILING IS DELIBERATELY NOT SET. The old one was 1320, derived
    from a single premature reading, and re-deriving it from one run of a
@@ -122,6 +145,7 @@ async function measure(origin, browser, i){
              preset: window.__preset().on, bench: new URL(location.href).searchParams.has("bench") };
   }, POSE);
 
+  const t0 = Date.now();
   const frames = await page.evaluate(([warm, n]) => new Promise((done) => {
     const r = window.__app.renderer, out = [];
     let seen = 0;
@@ -132,15 +156,26 @@ async function measure(origin, browser, i){
     requestAnimationFrame(tick);
   }), [WARMUP, SAMPLE]);
 
+  const elapsedMs = Date.now() - t0;
+  const env = await page.evaluate(() => {
+    const p = window.__preset();
+    return { dpr: p.dpr, rung: p.rung, rungWhy: p.rungWhy, presetOn: p.on,
+             crowd: window.__crowd().n, people: window.__students.length,
+             build: (document.documentElement.innerHTML.match(/const BUILD = "([^"]+)"/) || [,"?"])[1] };
+  });
   await shut();
-  return { ...stats(frames), n: frames.length, ...fixed };
+  return { ...stats(frames), sampled: frames.length, elapsedMs, ...fixed, ...env };
 }
 
 const { origin, close } = await serve();
 const browser = await launch();
 const { step, note, done } = reporter();
 
+let commit = "?";
+try { commit = execSync("git rev-parse --short HEAD", { encoding: "utf8" }).trim(); } catch {}
+const started = Date.now();
 console.log(`workload: ${LIVE ? "LIVE campus (diagnostic only)" : "deterministic"} · ` +
+            `profile ${PROFILE}${PROFILES[PROFILE].validated ? "" : " (UNVALIDATED — reports, does not gate)"} · ` +
             `1280x800 · warm ${WARMUP} · sample ${SAMPLE} · ${RUNS} launch(es)`);
 const all = [];
 for (let i = 0; i < RUNS; i++){
@@ -154,8 +189,46 @@ const p95s = all.map(r => r.p95);
 const spread = Math.max(...p95s) - Math.min(...p95s);
 note(`p95 across ${RUNS} launch(es): ${p95s.join(", ")}  ·  spread ${spread}`);
 
+/* THE RECORD. A number is comparable if you can put it beside another
+   one; it is REPRODUCIBLE only if everything that could have changed it
+   is written down next to it. This block is that, and it is emitted as
+   JSON so a run can be diffed against a run rather than remembered. */
+const record = {
+  benchVersion: BENCH_VERSION,
+  profile: PROFILE,
+  profileValidated: PROFILES[PROFILE].validated,
+  workload: LIVE ? "live" : "deterministic",
+  gates: !LIVE && PROFILES[PROFILE].validated && P95_CEILING != null,
+  commit,
+  build: all[0]?.build ?? "?",
+  viewport: "1280x800",
+  dpr: all[0]?.dpr ?? null,
+  ladderRung: all[0]?.rung ?? null,
+  ladderWhy: all[0]?.rungWhy ?? null,
+  arrivalPresetOn: all[0]?.presetOn ?? null,
+  crowdCount: all[0]?.crowd ?? null,
+  people: all[0]?.people ?? null,
+  cameraPose: POSE,
+  warmupFrames: WARMUP,
+  sampleFrames: SAMPLE,
+  launches: RUNS,
+  runs: all.map(r => ({ min: r.min, p50: r.p50, p90: r.p90, p95: r.p95, max: r.max,
+                        mean: r.mean, stddev: r.sd, sampled: r.sampled,
+                        elapsedMs: r.elapsedMs })),
+  p95Spread: spread,
+  p95Ceiling: P95_CEILING,
+  totalElapsedMs: Date.now() - started,
+};
+console.log("\n--- run record (JSON) ---");
+console.log(JSON.stringify(record, null, 1));
+if (OUT){ mkdirSync(OUT.replace(/\/[^/]*$/, "") || ".", { recursive: true });
+          writeFileSync(OUT, JSON.stringify(record, null, 1));
+          note(`record written to ${OUT}`); }
+
 if (LIVE){
   note("live workload — diagnostic only, never gates");
+} else if (!PROFILES[PROFILE].validated){
+  note(`profile "${PROFILE}" has not been shown to track the full profile — reporting only`);
 } else if (P95_CEILING == null){
   note("no ceiling set: re-baseline with --runs 5 on an unchanged main, more than once,");
   note("then set P95_CEILING above the highest p95 seen and say what it was measured on");

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -102,6 +102,40 @@ const POSE = { v: 1, pos: [-420, 300, 420], look: [0, 0, 0] };
    gate. */
 const P95_CEILING = null;
 
+/* FIRST BASELINE UNDER THE CONTRACT — recorded as data, not as a
+   ceiling. One launch, profile `ci`, commit a70dfe8, build pembroke-v150:
+ *
+ *     min 1482 · p50 1482 · p90 1483 · p95 1483 · max 1483
+ *     mean 1482.4 · stddev 0.5 · 90 frames
+ *     dpr 1 · ladder rung 0 (held) · preset off · crowd 9 · people 5
+ *
+ * STDDEV 0.5. Draw calls moved by one across the whole sample. The same
+ * campus measured by the method this replaces produced 711, 723, 765,
+ * 803, 1239, 1243, 1491 and 1609 — a nine-hundred-call swing, every
+ * reading correct at the moment it was taken and none of them
+ * comparable to another. That difference is the entire point of the
+ * workload contract, and it is why a future "15% improvement" now has
+ * to survive an equivalent workload rather than benefit from crowd
+ * timing.
+ *
+ * RUNTIME, and it decides where this can run. 120 frames took 18.7
+ * minutes here — about 9.4 seconds a frame on a software rasterizer
+ * with no GPU. The full profile's 420 frames would be roughly 66
+ * minutes, which matches a full-profile attempt that ran past 51
+ * without reaching its first result. On a runner holding 60fps the same
+ * two profiles are about 2 and 7 seconds.
+ *
+ *   So: this belongs on a GPU runner, or on a schedule. It is not a
+ *   per-PR gate on a software rasterizer at any profile, and pretending
+ *   otherwise would trade one badly-specified instrument for a
+ *   well-specified one nobody can afford to run.
+ *
+ * STILL MISSING before a ceiling can be set: several independent
+ * launches, on the machine that will actually enforce it, and evidence
+ * that the `ci` profile's p95 tracks `full`'s. One launch establishes
+ * that the workload is stable; it does not establish where the line
+ * goes. */
+
 const stats = (a) => {
   const s = [...a].sort((x, y) => x - y);
   const q = (p) => s[Math.min(s.length - 1, Math.floor(s.length * p))];

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -1,0 +1,167 @@
+#!/usr/bin/env node
+/**
+ * Pembroke Academy — a draw-call measurement with a defined workload.
+ *
+ *     node tools/check-perf.mjs                 deterministic, gated
+ *     node tools/check-perf.mjs --live          live campus, diagnostic
+ *     node tools/check-perf.mjs --runs 5        repeat, for baselining
+ *
+ * WHY THIS EXISTS, AND WHAT IT REPLACES.
+ *
+ * check-frame used to assert a ceiling on "the settled draw count". It
+ * settled by waiting for two twelve-second windows to agree within 2,
+ * and that was believed to mean the campus had finished arriving.
+ *
+ * It does not. Measured:
+ *
+ *     two agreeing windows      1243 draws   (arrivalState: not arriving)
+ *     kept waiting              1609 draws
+ *
+ * +366, and `arriving` was ALREADY false at 1243 — arrivalState tracks
+ * the asset log, while the crowd goes on churning by design, bodies
+ * walking into buildings and out again for the whole session. THIS
+ * SCENE NEVER STOPS CHANGING. "Wait until it settles" is not a workload
+ * specification, and a ceiling derived from one arbitrary moment in a
+ * continuously moving scene has no stable meaning. It gated merges for
+ * a day on an envelope nobody had defined.
+ *
+ * A performance gate needs to say what it is measuring. This does:
+ *
+ *     fixed build            whatever is checked out
+ *     fixed viewport + DPR   1280x800 at pixelRatio 1
+ *     fixed graphics preset  ?bench holds the quality ladder
+ *     fixed camera           set here, and ?bench stops anything moving it
+ *     fixed crowd            __crowdFill(), then ?bench freezes their motion
+ *     wait for              assets only — not for the scene to hold still
+ *     warm                  WARMUP frames, discarded
+ *     sample                SAMPLE frames
+ *     report                min, p50, p90, p95, max, mean, stddev
+ *
+ * THE GATE IS p95, not a one-time median: a single reading of a moving
+ * scene is the thing that got us here.
+ *
+ * TWO MEASUREMENTS, and only one of them gates.
+ *
+ *   deterministic (default)  camera fixed, crowd frozen. Comparable run
+ *                            to run, which is the only property a
+ *                            regression gate needs. THIS ONE GATES.
+ *   --live                   normal churn. Answers a different question
+ *                            — what the distribution looks like during
+ *                            one stochastic simulation — and carries
+ *                            seed, population and timing variance. Good
+ *                            as a soak diagnostic, poor as a gate, so it
+ *                            never fails the build.
+ *
+ * BASELINING. Do not set the ceiling from one run. `--runs 5` launches
+ * five independent browsers and prints the spread across them; the
+ * ceiling belongs above the highest p95 seen across several such
+ * launches, with the reason written down.
+ */
+import { serve, launch, reporter } from "./_harness.mjs";
+
+const argv = process.argv.slice(2);
+const LIVE  = argv.includes("--live");
+const RUNS  = Math.max(1, +(argv[argv.indexOf("--runs") + 1] || 1) || 1);
+const WARMUP = 120;
+const SAMPLE = 300;
+
+/* The pose. It lives HERE, in the tool, because the camera position is
+   part of the workload specification and not part of the campus. The
+   quad from the north-west, high enough to hold the whole academic
+   range — the view a visitor actually arrives on. */
+const POSE = { pos: [-420, 300, 420], look: [0, 0, 0] };
+
+/* THE CEILING IS DELIBERATELY NOT SET. The old one was 1320, derived
+   from a single premature reading, and re-deriving it from one run of a
+   new method would repeat exactly that mistake. Run --runs 5 on an
+   unchanged main, several times, then put the number here with a note
+   saying what it was measured on. Until then this reports and does not
+   gate. */
+const P95_CEILING = null;
+
+const stats = (a) => {
+  const s = [...a].sort((x, y) => x - y);
+  const q = (p) => s[Math.min(s.length - 1, Math.floor(s.length * p))];
+  const mean = s.reduce((x, y) => x + y, 0) / s.length;
+  const sd = Math.sqrt(s.reduce((t, v) => t + (v - mean) ** 2, 0) / s.length);
+  return { min: s[0], p50: q(.5), p90: q(.9), p95: q(.95), max: s[s.length - 1],
+           mean: +mean.toFixed(1), sd: +sd.toFixed(1) };
+};
+
+async function measure(origin, browser, i){
+  /* Not the harness's open(): it navigates to "/", and this workload
+     needs its own query string. Booting the campus twice to get there
+     would cost minutes per run for nothing. */
+  const qs = LIVE ? "?crowd" : "?crowd&bench";
+  const ctx = await browser.newContext({ viewport: { width: 1280, height: 800 } });
+  const page = await ctx.newPage();
+  const shut = () => ctx.close();
+  await page.goto(origin + "/" + qs, { waitUntil: "domcontentloaded", timeout: 90_000 });
+  const up = await page.waitForFunction(() => window.__app && window.__crowd, null,
+      { timeout: 240_000 }).then(() => true, () => false);
+  if (!up) throw new Error("the campus did not ignite");
+  await page.waitForFunction(() => !document.body.classList.contains("opening"),
+      null, { timeout: 120_000 }).catch(() => {});
+
+  /* WAIT FOR ASSETS ONLY. Not for the scene to hold still — it never
+     does, and that belief is the defect this file exists to retire. */
+  await page.waitForFunction(() => window.__crowd().pending === 0, null,
+      { timeout: 600_000, polling: 2000 }).catch(() => {});
+  await page.waitForFunction(() => window.__preset && window.__preset().on === false,
+      null, { timeout: 600_000, polling: 2000 }).catch(() => {});
+
+  const fixed = await page.evaluate(async (P) => {
+    window.__crowdFill();
+    const { camera, controls } = window.__app;
+    camera.position.set(...P.pos);
+    camera.lookAt(...P.look);
+    camera.updateMatrixWorld(true);
+    if (controls){ controls.target.set(...P.look); controls.update(); }
+    await new Promise(r => setTimeout(r, 1500));
+    return { people: window.__students.length, dpr: window.__app.renderer.getPixelRatio(),
+             preset: window.__preset().on, bench: new URL(location.href).searchParams.has("bench") };
+  }, POSE);
+
+  const frames = await page.evaluate(([warm, n]) => new Promise((done) => {
+    const r = window.__app.renderer, out = [];
+    let seen = 0;
+    const tick = () => {
+      if (seen++ >= warm) out.push(r.info.render.calls);
+      if (out.length < n) requestAnimationFrame(tick); else done(out);
+    };
+    requestAnimationFrame(tick);
+  }), [WARMUP, SAMPLE]);
+
+  await shut();
+  return { ...stats(frames), n: frames.length, ...fixed };
+}
+
+const { origin, close } = await serve();
+const browser = await launch();
+const { step, note, done } = reporter();
+
+console.log(`workload: ${LIVE ? "LIVE campus (diagnostic only)" : "deterministic"} · ` +
+            `1280x800 · warm ${WARMUP} · sample ${SAMPLE} · ${RUNS} launch(es)`);
+const all = [];
+for (let i = 0; i < RUNS; i++){
+  const r = await measure(origin, browser, i);
+  all.push(r);
+  console.log(`  run ${i + 1}: min ${r.min}  p50 ${r.p50}  p90 ${r.p90}  p95 ${r.p95}  ` +
+              `max ${r.max}  mean ${r.mean}  sd ${r.sd}   (${r.people} people, dpr ${r.dpr}, ` +
+              `bench=${r.bench}, preset=${r.preset})`);
+}
+const p95s = all.map(r => r.p95);
+const spread = Math.max(...p95s) - Math.min(...p95s);
+note(`p95 across ${RUNS} launch(es): ${p95s.join(", ")}  ·  spread ${spread}`);
+
+if (LIVE){
+  note("live workload — diagnostic only, never gates");
+} else if (P95_CEILING == null){
+  note("no ceiling set: re-baseline with --runs 5 on an unchanged main, more than once,");
+  note("then set P95_CEILING above the highest p95 seen and say what it was measured on");
+} else {
+  step(`p95 draw calls within the ceiling`, Math.max(...p95s) <= P95_CEILING,
+       `${Math.max(...p95s)} against ${P95_CEILING}`);
+}
+await browser.close(); close();
+done("performance");

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -65,6 +65,7 @@ const argv = process.argv.slice(2);
 const LIVE  = argv.includes("--live");
 const RUNS  = Math.max(1, +(argv[argv.indexOf("--runs") + 1] || 1) || 1);
 const OUT   = argv.includes("--out") ? argv[argv.indexOf("--out") + 1] : null;
+const CALIBRATE = argv.includes("--calibrate");
 
 /* BENCH_VERSION changes whenever anything about the workload changes —
    the pose, the frame counts, what ?bench freezes. Numbers from
@@ -135,6 +136,35 @@ const P95_CEILING = null;
  * that the `ci` profile's p95 tracks `full`'s. One launch establishes
  * that the workload is stable; it does not establish where the line
  * goes. */
+
+/* ── CALIBRATION, SPECIFIED ───────────────────────────────────────────
+   The workload needed a specification and so does the calibration, for
+   the same reason: "run it a few times and pick a number" is how 1320
+   happened. --calibrate is that procedure as a command.
+ *
+ *   MIN_LAUNCHES   three is not several. Five independent launches, so
+ *                  that one anomalous boot cannot set the line.
+ *   same runner    a ceiling calibrated on a software rasterizer does
+ *                  not describe a GPU runner, and vice versa. The
+ *                  record carries the commit and the profile; it cannot
+ *                  carry the machine, so that part stays a human
+ *                  responsibility and is printed as a warning.
+ *   unchanged main the point is the baseline, not the branch.
+ *   ACCEPT_SPREAD  if p95 varies by more than this across launches the
+ *                  workload is not yet deterministic enough to gate on,
+ *                  and the answer is to fix the workload rather than to
+ *                  pad the ceiling.
+ *   HEADROOM       what separates the ceiling from the highest p95 seen.
+ *                  Small on purpose: a wide margin is a gate that never
+ *                  fires, which is the same as no gate with extra
+ *                  ceremony.
+ *
+ *   It PRINTS a recommendation and never writes one. Setting the number
+ *   is a decision with a reason attached, and the reason belongs in the
+ *   commit that sets it. */
+const MIN_LAUNCHES = 5;
+const ACCEPT_SPREAD = 25;      /* p95 draw calls, across launches */
+const HEADROOM = 0.03;         /* 3% above the worst p95 observed */
 
 const stats = (a) => {
   const s = [...a].sort((x, y) => x - y);
@@ -259,7 +289,36 @@ if (OUT){ mkdirSync(OUT.replace(/\/[^/]*$/, "") || ".", { recursive: true });
           writeFileSync(OUT, JSON.stringify(record, null, 1));
           note(`record written to ${OUT}`); }
 
-if (LIVE){
+if (CALIBRATE){
+  const worst = Math.max(...p95s), best = Math.min(...p95s);
+  console.log("\n=== calibration ===");
+  console.log(`  launches            ${RUNS}${RUNS < MIN_LAUNCHES ? `  — WANT AT LEAST ${MIN_LAUNCHES}` : ""}`);
+  console.log(`  p95 per launch      ${p95s.join(", ")}`);
+  console.log(`  spread              ${spread}  (accept <= ${ACCEPT_SPREAD})`);
+  console.log(`  worst p95           ${worst}`);
+  const enough = RUNS >= MIN_LAUNCHES;
+  const stable = spread <= ACCEPT_SPREAD;
+  const validProfile = PROFILES[PROFILE].validated;
+  if (!enough) console.log(`\n  NOT ENOUGH LAUNCHES — run --calibrate --runs ${MIN_LAUNCHES} or more.`);
+  if (!stable) console.log(`\n  SPREAD TOO WIDE — p95 moved ${spread} across launches. Fix the` +
+                           `\n  workload rather than padding the ceiling: something is still free` +
+                           `\n  to vary. The record above names every field that was controlled.`);
+  if (!validProfile) console.log(`\n  PROFILE "${PROFILE}" IS UNVALIDATED — calibrate on "full", or first` +
+                                 `\n  show that this profile's p95 tracks it.`);
+  if (LIVE) console.log(`\n  LIVE WORKLOAD — cannot calibrate a gate from a stochastic run.`);
+  if (enough && stable && validProfile && !LIVE){
+    const rec = Math.ceil(worst * (1 + HEADROOM));
+    console.log(`\n  RECOMMENDED P95_CEILING = ${rec}   (worst ${worst} + ${(HEADROOM*100).toFixed(0)}%)`);
+    console.log(`  Set it by hand, in a commit that says which machine this ran on —`);
+    console.log(`  the record carries the commit and the profile but cannot carry the`);
+    console.log(`  hardware, and a ceiling from one class of runner does not describe`);
+    console.log(`  another.`);
+  } else {
+    console.log(`\n  NO RECOMMENDATION. The conditions above are the whole point;`);
+    console.log(`  a number produced without them is how the last ceiling happened.`);
+  }
+  note("calibration prints a recommendation and never writes one");
+} else if (LIVE){
   note("live workload — diagnostic only, never gates");
 } else if (!PROFILES[PROFILE].validated){
   note(`profile "${PROFILE}" has not been shown to track the full profile — reporting only`);


### PR DESCRIPTION
**Measurement validity only. No optimization in this branch** — mixing it in would contaminate the baseline this exists to make credible.

## The headline, stated correctly

The old numbers did not *vary*. **The old instrument was measuring different workloads.**

That distinction is the whole PR. A spread of 711 → 1609 draw calls looks like a noisy renderer; it was nothing of the kind. Each reading was correct at the instant it was taken, and each was taken of a *different campus* — one holding 700 draw calls' worth of people is simply not the same workload as one holding 1,600. Hold the workload still and the count moves by **one** across ninety frames.

```
retracted method   711, 723, 765, 803, 1239, 1243, 1491, 1609
this contract      min 1482 · p50 1482 · p90 1483 · p95 1483 · max 1483
                   mean 1482.4 · stddev 0.5 · 90 frames
```

The variance was never in the renderer. It was in what the instrument was pointed at.

## The gate that was merged is withdrawn

`check-frame` asserted `drawCalls &lt;= 1320`. It is **removed, not re-tuned**, because the number it compared and the number it compared against were both taken at a moment nobody had defined.

```
check-frame&#39;s own rule     1243 draws   (arrivalState: not arriving)
kept waiting               1609 draws
```

**+366** — and the obvious repair fails too: `arriving` was **already false** at 1243. `arrivalState` tracks the asset log, while the crowd churns by design, bodies walking into buildings and out again all session. **This scene never stops changing**, so &#34;two windows agreed&#34; was luck, not convergence.

Leaving it in would have been worse than deleting it. A green build would claim the campus stayed inside an envelope that was never defined — a broken instrument promoted to policy.

## What replaces it

`tools/check-perf.mjs`, which states the workload instead of waiting for the scene to hold still:

```
fixed build · fixed viewport 1280×800 · fixed pixel ratio
fixed graphics preset   ?bench holds the quality ladder
fixed camera            set by the TOOL — the pose is part of the workload
                        specification, not part of the campus
fixed crowd             __crowdFill(), then frozen where they stand
wait for                assets only
warm 120 · sample 300 · report min p50 p90 p95 max mean stddev
```

The gate is **p95**, not a one-time median. One reading of a moving scene is the thing that got us here.

`?bench` is **a workload, not a rendering mode**: it freezes crowd motion, camera, ladder and clock, and changes nothing about how a frame is drawn — same passes, same materials, same shadow map.

## Two measurements, one of which gates

| | |
|---|---|
| **deterministic** | fixed camera, frozen crowd — comparable launch to launch. **This one gates.** |
| **`--live`** | normal churn; the distribution during one stochastic simulation, carrying seed, population and timing variance. Soak diagnostic. **Never fails a build.** |

## Provenance: the workload is only half of a measurement

The other half is the machine. Two runs under an identical workload specification are still incomparable if one came off a GPU and the other off a software rasterizer — and until now nothing in the record said which.

Every run record now carries an `environment` block:

```
gpu                  GPU + driver string, from WEBGL_debug_renderer_info
hardwareAccelerated  ← the field that decides whether a ceiling transfers
browser              name + version
userAgent · os · cpus · totalMemGB
runnerImage · runnerOS · ci      where CI provides them
```

The page publishes it via `window.__gpu()`, beside the `softGL` detection the quality ladder already performed — nothing new is *detected*, it is only written down.

`--calibrate` prints that provenance above its recommendation and **refuses to recommend at all when acceleration was off**. Verified here, which is exactly the case it exists for:

```
ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)
accelerated: false
```

A ceiling calibrated there would describe SwiftShader, and CI is not SwiftShader. The commit that eventually sets `P95_CEILING` is required to paste this block beside the number.

## Runtime decides where this can run

**18.7 minutes for 120 frames** here — ~9.4 s/frame on a software rasterizer. The full profile&#39;s 420 frames extrapolates to ~66 minutes, matching a full-profile attempt that ran past 51 without reaching its first result line. On a runner holding 60fps: ~2s and ~7s.

**This belongs on a GPU runner or on a schedule.** It is not a per-PR gate on a software rasterizer at any profile, and shipping it as one would trade a badly-specified instrument for a well-specified one nobody can afford to run.

## Deliberately unset, and why

| | |
|---|---|
| `P95_CEILING` | **null.** One launch proves the workload is stable; it does not prove where the line goes |
| `ci` profile (30/90) | **UNVALIDATED** — nobody has shown its p95 tracks `full`&#39;s. Reports, does not gate |
| scenery-fold branch | **stays closed** until it can be re-measured under this contract |

## The run record

Every field that could have changed the number, emitted as JSON so a run is diffed rather than remembered: commit, `BUILD`, `BENCH_VERSION`, profile, workload, viewport, DPR, **ladder rung and the reason it stopped there**, arrival-preset state, crowd count, people, camera pose with its own version, warmup/sample counts, launches, full distribution, p95 spread, ceiling in force, elapsed per run and total — and now the `environment` block above.

It earned its keep immediately: `crowdCount: 9, people: 5` — the on-screen MB ceiling limited the fill on this machine. Under the old method that was an invisible source of variance.

## Calibration is specified too

`--calibrate` makes the next step a command rather than a ritual, because *&#34;run it a few times and pick a number&#34;* is exactly how 1320 happened.

- **`MIN_LAUNCHES = 5`** — three is not several
- **`ACCEPT_SPREAD = 25`** — a wider spread means **fix the workload, don&#39;t pad the ceiling**; something is still free to vary and the record names every field that was controlled
- **`HEADROOM = 3%`** — a wide margin is a gate that never fires

It refuses to recommend when the conditions aren&#39;t met and says which one failed. It **prints** a recommendation and never writes one: setting the ceiling is a decision with a reason, and the reason belongs in the commit that sets it — now including the hardware, which the record finally carries.

## Retraction in the audit

`docs/REPO_INTEGRITY_AUDIT.md` §9.1 now carries, verbatim:

&gt; Previous draw-call values and the reported 22.9% delta were generated from measurements taken at non-equivalent points in a continuously changing scene. They are retained as historical observations but are not valid comparative performance measurements.

…followed by the framing at the top of this description, and by the provenance requirement binding the eventual ceiling-setting commit.

What survives is the structural claim, which never depended on a sample: **no rung of the five-rung ladder removes a draw call** — every rung alters fill-rate parameters and none removes objects, materials or passes. That is an architectural fact read from the ladder&#39;s own definition.

## Next step is calibration, not code

Several independent launches on unchanged `main`, **on the hardware that will enforce the gate**, same `BENCH_VERSION` and profile; compare the p95 distribution; only then set a ceiling, with the `environment` block pasted into that commit. Separately, validate whether the short profile tracks the full one closely enough to be useful.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_