### PR TITLE
Calibrate against the machine that enforces, not against a GPU

### DIFF
--- a/.github/workflows/calibrate.yml
+++ b/.github/workflows/calibrate.yml
@@ -1,0 +1,129 @@
+name: calibrate the performance ceiling
+
+# NOT A GATE, AND NEVER RUNS BY ITSELF.
+#
+# This is the run that produces a number for a human to set by hand. It
+# is workflow_dispatch only — no push trigger, no pull_request trigger —
+# because it costs an hour and a half of runner time and its output is a
+# recommendation, not a verdict. Nothing here can fail a build.
+#
+# WHY IT RUNS HERE, on an ordinary GitHub-hosted runner with no GPU.
+#
+# The rule for calibrating a gate is that the machine which calibrates
+# must match the machine that enforces. Every probe in this repository
+# launches Chromium with --enable-unsafe-swiftshader (tools/_harness.mjs)
+# because GitHub-hosted runners have no GPU — so the enforcing machine
+# IS a software rasterizer, and calibrating on one is not a compromise,
+# it is the procedure. check-perf.mjs declares that expectation as
+# ENFORCEMENT and refuses to recommend a ceiling anywhere that does not
+# match it, naming the field that differs.
+#
+# The records are uploaded rather than printed alone: the commit that
+# eventually sets P95_CEILING has to carry the provenance, and copying it
+# out of an artifact is how that happens without retyping numbers.
+on:
+  workflow_dispatch:
+    inputs:
+      profile:
+        description: 'full (120 warm / 300 sample) or ci (30 / 90)'
+        type: choice
+        options: [full, ci]
+        default: full
+      runs:
+        description: 'independent browser launches — five is the minimum that calibrates'
+        default: '5'
+      both:
+        description: 'also run the ci profile afterwards, to see whether its p95 tracks full'
+        type: boolean
+        default: false
+
+concurrency:
+  group: calibrate-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  PW_VERSION: '1.56.1'
+
+jobs:
+  calibrate:
+    runs-on: ubuntu-latest
+    # Five launches of the full profile is the expensive case. Measured
+    # at roughly 9.4 s/frame on a software rasterizer, 420 frames a
+    # launch, so ~66 minutes each — and the budget has to cover the case
+    # where the runner is slower than the box this was measured on.
+    timeout-minutes: 360
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # Same cache key and the same timings as the smoke job, for the
+      # same reason: an install that wedges should cost minutes and fail
+      # as itself, not drain a six-hour budget and report "cancelled".
+      - name: Cache the browser
+        id: browser
+        timeout-minutes: 5
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ env.PW_VERSION }}
+
+      - name: Install Playwright
+        timeout-minutes: 6
+        run: npm install --no-save --no-audit --no-fund playwright@${{ env.PW_VERSION }}
+
+      - name: Fetch the browser
+        if: steps.browser.outputs.cache-hit != 'true'
+        timeout-minutes: 8
+        run: npx playwright install --with-deps chromium
+
+      - name: System libraries for the cached browser
+        if: steps.browser.outputs.cache-hit == 'true'
+        timeout-minutes: 6
+        run: npx playwright install-deps chromium
+
+      # What the machine actually is, before anything is measured on it.
+      # The record carries this too; having it in the log means a reader
+      # scrolling the run can see what they are reading without opening
+      # the artifact.
+      - name: What is this runner?
+        run: |
+          echo "image     ${ImageOS:-unknown} · ${RUNNER_OS:-unknown} · ${RUNNER_ARCH:-unknown}"
+          echo "cpus      $(nproc)"
+          echo "memory    $(free -g | awk '/^Mem:/{print $2}') GB"
+          echo "kernel    $(uname -srm)"
+
+      - name: Calibrate
+        run: |
+          node tools/check-perf.mjs --calibrate \
+            --profile "${{ inputs.profile }}" \
+            --runs "${{ inputs.runs }}" \
+            --out "perf-records/${{ inputs.profile }}.json"
+
+      # The second half of the question the first half cannot answer.
+      # The ci profile is marked UNVALIDATED in check-perf.mjs because
+      # nobody has shown its p95 tracks the full profile's — and until
+      # somebody does, it must not be allowed to fail a build. This step
+      # is how that gets shown: same commit, same runner, both profiles,
+      # and the two p95 distributions to compare.
+      - name: And the short profile, for comparison
+        if: inputs.both && inputs.profile == 'full'
+        run: |
+          node tools/check-perf.mjs --calibrate \
+            --profile ci \
+            --runs "${{ inputs.runs }}" \
+            --out "perf-records/ci.json"
+
+      # always(): a timeout or a refusal still produced records worth
+      # keeping, and the refusal path is the one whose evidence is most
+      # likely to be wanted.
+      - name: Keep the records
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: perf-records-${{ github.sha }}
+          path: perf-records/
+          if-no-files-found: warn
+          retention-days: 90

--- a/tools/README.md
+++ b/tools/README.md
@@ -74,6 +74,7 @@ authoring pipelines rather than gates:
 
 | workflow | fires on | scripts |
 |---|---|---|
+| `calibrate.yml` | **nothing — `workflow_dispatch` only** | `check-perf.mjs --calibrate`. Produces a *recommendation* for `P95_CEILING`, never a verdict; cannot fail a build. It runs on an ordinary GPU-less runner on purpose: the machine that calibrates has to match the machine that enforces, and the enforcing machine is a software rasterizer. Records upload as an artifact so the commit that sets the number can carry its provenance |
 | `materials.yml` | `check-materials.mjs` changes | `check-materials.mjs` |
 | `mixamo.yml` | `tools/mixamo-inbox.txt` changes | `mixamo-plan.py` · `mixamo-to-glb.py` · `flatten-scenes.mjs` · `thin-character.mjs` |
 | `inspect.yml` | `tools/inspect-inbox.txt` changes | `inspect-rig.py` |

--- a/tools/check-perf.mjs
+++ b/tools/check-perf.mjs
@@ -58,14 +58,15 @@
  * launches, with the reason written down.
  *
  * PROVENANCE. The workload above is half of a measurement; the machine
- * is the other half. Every record carries `environment` — GPU and
- * driver string, WHETHER HARDWARE ACCELERATION WAS ACTUALLY ACTIVE,
- * browser and version, OS, CPUs, memory, and the CI runner image where
- * CI provides it. The accelerated flag is the one that decides whether
- * a ceiling transfers: SwiftShader and a real GPU are not the same
- * measurement however identical the workload was, so --calibrate
- * refuses to recommend a number when acceleration was off, and the
- * commit that sets P95_CEILING must paste this block beside it.
+ * is the other half. Every record carries `environment` — renderer and
+ * driver string, whether hardware acceleration was active, browser and
+ * version, OS, CPUs, memory, and the CI runner image where CI provides
+ * it — together with the ENFORCEMENT target it was compared against.
+ * The rule is not "measure on a GPU"; it is that the machine which
+ * calibrates must match the machine that enforces. --calibrate refuses
+ * to recommend a number off-target and says which field differs, and
+ * the commit that sets P95_CEILING must paste this block beside it. See
+ * ENFORCEMENT below for why the target here is a software rasterizer.
  */
 import { serve, launch, reporter } from "./_harness.mjs";
 import { execSync } from "node:child_process";
@@ -111,7 +112,12 @@ const POSE = { v: 1, pos: [-420, 300, 420], look: [0, 0, 0] };
    new method would repeat exactly that mistake. Run --runs 5 on an
    unchanged main, several times, then put the number here with a note
    saying what it was measured on. Until then this reports and does not
-   gate. */
+   gate.
+
+   The run that produces the number is `.github/workflows/calibrate.yml`
+   — dispatch it by hand, take the recommendation out of the artifact,
+   and paste the record's `environment` and `enforcementTarget` into the
+   commit that sets this constant. */
 const P95_CEILING = null;
 
 /* FIRST BASELINE UNDER THE CONTRACT — recorded as data, not as a
@@ -176,6 +182,55 @@ const P95_CEILING = null;
 const MIN_LAUNCHES = 5;
 const ACCEPT_SPREAD = 25;      /* p95 draw calls, across launches */
 const HEADROOM = 0.03;         /* 3% above the worst p95 observed */
+
+/* THE ENFORCEMENT TARGET — the machine the gate will RUN ON.
+ *
+ * An earlier version of this file refused to recommend a ceiling
+ * whenever hardware acceleration was off, on the reasoning that "a
+ * number from SwiftShader does not describe a GPU runner". That rule is
+ * wrong, and wrong in the direction that blocks the only calibration
+ * this project can actually perform.
+ *
+ * GitHub-hosted runners have no GPU. Every probe here launches with
+ * --enable-unsafe-swiftshader (tools/_harness.mjs), so the machine that
+ * would ENFORCE a perf gate is a software rasterizer — permanently,
+ * short of buying GPU runners. Calibrating under SwiftShader for a gate
+ * that runs under SwiftShader is not a compromise. It is the procedure.
+ *
+ * The real requirement was never "measure on a GPU". It is: THE MACHINE
+ * THAT CALIBRATES MUST MATCH THE MACHINE THAT ENFORCES. So the target is
+ * declared, and the run is compared against it.
+ *
+ * WHAT IS COMPARED, AND WHY ONLY THIS. The metric is a draw-call COUNT,
+ * not a duration, so most of what differs between machines cannot move
+ * it: core count, clock speed and memory bandwidth change how long a
+ * frame takes, not how many submissions it contains. What CAN move the
+ * count is anything that changes which passes and which objects exist —
+ * renderer class (extension and capability support decides whether a
+ * pass can be built at all), platform, and browser, since Three's
+ * capability detection is what composes the chain. Those are compared.
+ * CPU and RAM are recorded for the reader and deliberately not gated
+ * on; claiming they matter here would be ceremony, not rigour. */
+const ENFORCEMENT = {
+  id: "github-hosted · ubuntu · chromium · swiftshader",
+  platform: "linux",
+  browser: "chromium",
+  hardwareAccelerated: false,
+  why: "GitHub-hosted runners have no GPU and _harness.mjs launches with --enable-unsafe-swiftshader",
+};
+
+/** Everything about this run that disqualifies it from calibrating the target. */
+function targetMismatch(env, target){
+  const out = [];
+  if (env.hardwareAccelerated !== target.hardwareAccelerated)
+    out.push(`hardware acceleration is ${env.hardwareAccelerated} here, ` +
+             `${target.hardwareAccelerated} on the target`);
+  if (!String(env.os).startsWith(target.platform))
+    out.push(`platform is "${env.os}" here, "${target.platform}" on the target`);
+  if (!String(env.browser).startsWith(target.browser))
+    out.push(`browser is "${env.browser}" here, "${target.browser}" on the target`);
+  return out;
+}
 
 const stats = (a) => {
   const s = [...a].sort((x, y) => x - y);
@@ -313,6 +368,8 @@ const record = {
                         elapsedMs: r.elapsedMs })),
   p95Spread: spread,
   p95Ceiling: P95_CEILING,
+  enforcementTarget: ENFORCEMENT.id,
+  enforcementMismatch: targetMismatch(environment, ENFORCEMENT),
   totalElapsedMs: Date.now() - started,
 };
 console.log("\n--- run record (JSON) ---");
@@ -338,23 +395,31 @@ if (CALIBRATE){
   if (!validProfile) console.log(`\n  PROFILE "${PROFILE}" IS UNVALIDATED — calibrate on "full", or first` +
                                  `\n  show that this profile's p95 tracks it.`);
   if (LIVE) console.log(`\n  LIVE WORKLOAD — cannot calibrate a gate from a stochastic run.`);
-  console.log(`  measured on         ${environment.gpu || "unknown GPU"}`);
-  console.log(`  hardware accelerated ${environment.hardwareAccelerated}` +
-              (environment.hardwareAccelerated === false
-                 ? "   *** a ceiling from a software rasterizer does not describe a GPU runner ***" : ""));
+  const mismatch = targetMismatch(environment, ENFORCEMENT);
+  const onTarget = mismatch.length === 0;
+  console.log(`  enforcement target  ${ENFORCEMENT.id}`);
+  console.log(`  measured on         ${environment.gpu || "unknown renderer"}`);
+  console.log(`  hardware accelerated ${environment.hardwareAccelerated}`);
   console.log(`  browser / os        ${environment.browser} · ${environment.os}` +
               (environment.runnerImage ? ` · image ${environment.runnerImage}` : ""));
-  if (enough && stable && validProfile && !LIVE){
+  console.log(`  cpus / memory       ${environment.cpus} · ${environment.totalMemGB} GB` +
+              `   (recorded, not gated on — see ENFORCEMENT)`);
+  console.log(`  matches the target  ${onTarget ? "yes" : "NO"}`);
+  if (!onTarget){
+    console.log(`\n  NOT THE ENFORCING MACHINE — a ceiling calibrated here would gate`);
+    console.log(`  something else. What differs:`);
+    for (const m of mismatch) console.log(`    · ${m}`);
+    console.log(`  Either calibrate on the target, or change ENFORCEMENT to name`);
+    console.log(`  the machine that will actually run the gate — deliberately, in`);
+    console.log(`  a commit. Do not calibrate here and hope.`);
+  }
+  if (enough && stable && validProfile && !LIVE && onTarget){
     const rec = Math.ceil(worst * (1 + HEADROOM));
     console.log(`\n  RECOMMENDED P95_CEILING = ${rec}   (worst ${worst} + ${(HEADROOM*100).toFixed(0)}%)`);
-    console.log(`  Set it by hand, in a commit that carries the provenance printed`);
-    console.log(`  above: GPU and driver string, whether acceleration was ACTIVE,`);
-    console.log(`  browser and version, runner image and OS. The record block holds`);
-    console.log(`  all of it — paste it into the commit that sets the number.`);
-    if (environment.hardwareAccelerated === false){
-      console.log(`\n  BUT NOT FROM THIS RUN: acceleration was not active. This number`);
-      console.log(`  describes a software rasterizer and must not gate a GPU runner.`);
-    }
+    console.log(`  Set it by hand, in a commit carrying the provenance printed above:`);
+    console.log(`  renderer, acceleration state, browser and version, runner image`);
+    console.log(`  and OS, and the enforcement target it was matched against. The`);
+    console.log(`  record block holds all of it — paste it into that commit.`);
   } else {
     console.log(`\n  NO RECOMMENDATION. The conditions above are the whole point;`);
     console.log(`  a number produced without them is how the last ceiling happened.`);


### PR DESCRIPTION
**Fixes a rule I shipped yesterday that was wrong in the direction that blocks the only calibration this project can perform.**

## The bug

`--calibrate` refused to recommend a ceiling whenever `hardwareAccelerated === false`, reasoning that a SwiftShader number cannot describe a GPU runner.

But **GitHub-hosted runners have no GPU**, and every probe here launches with `--enable-unsafe-swiftshader` (`tools/_harness.mjs:65`). The machine that would *enforce* a perf gate is a software rasterizer, permanently, short of buying GPU runners. So the old rule would have rejected the correct calibration and demanded hardware that will never run the check — leaving `P95_CEILING` unset forever, and repair 10 (the scenery merge, the last open P1) blocked on a purchase.

Calibrating under SwiftShader for a gate that runs under SwiftShader is not a compromise. **It is the procedure.**

## The rule, stated as what it always was

> The machine that calibrates must match the machine that enforces.

```js
const ENFORCEMENT = {
  id: "github-hosted · ubuntu · chromium · swiftshader",
  platform: "linux", browser: "chromium", hardwareAccelerated: false,
  why: "GitHub-hosted runners have no GPU and _harness.mjs launches with --enable-unsafe-swiftshader",
};
```

`targetMismatch()` compares the run against it; `--calibrate` refuses off-target and **names the field that differs** rather than printing a verdict. The record gains `enforcementTarget` and `enforcementMismatch`.

## What is compared, and what deliberately is not

The metric is a draw-call **count**, not a duration. Core count, clock speed and memory bandwidth change how long a frame takes, not how many submissions it contains — so they are **recorded and not gated on**. What *can* move the count is anything altering which passes and objects exist: renderer class (extension and capability support decides whether a pass can be built at all), platform, and browser, since Three's capability detection composes the chain. Those three are compared.

Gating on CPU and RAM would have looked more rigorous and been pure ceremony.

## Verified in both directions

**On target** (this box is linux/chromium/swiftshader, `--profile ci --runs 1`):

```
 "enforcementTarget": "github-hosted · ubuntu · chromium · swiftshader",
 "enforcementMismatch": [],
  matches the target  yes
  NOT ENOUGH LAUNCHES — run --calibrate --runs 5 or more.
  PROFILE "ci" IS UNVALIDATED …
  NO RECOMMENDATION.
```

It still refuses — but on launches and profile validity, **not** on `hardware accelerated false`. Under the old rule that same run was rejected as unfit hardware, which was the bug.

That run also independently replicated the stability claim on a different commit: `min 1482 · p95 1483 · stddev 0.5`, matching the first baseline exactly.

**Off target** — the same run with `ENFORCEMENT` flipped to a GPU. This completed after the PR was opened, and here is the output:

```
  enforcement target  TEST · a GPU runner
  measured on         ANGLE (Google, Vulkan 1.3.0 (SwiftShader Device (Subzero)), SwiftShader driver)
  hardware accelerated false
  matches the target  NO

  NOT THE ENFORCING MACHINE — a ceiling calibrated here would gate
  something else. What differs:
    · hardware acceleration is false here, true on the target

  NO RECOMMENDATION. The conditions above are the whole point;
  a number produced without them is how the last ceiling happened.
```

The refusal fires and names the field. Both directions are now shown, which is what the original version of this description said it would wait for.

## `.github/workflows/calibrate.yml`

**`workflow_dispatch` only.** No push trigger, no `pull_request` trigger, nothing in it can fail a build. It costs over an hour of runner time and its output is a recommendation, not a verdict.

| input | |
|---|---|
| `profile` | `full` (120/300) or `ci` (30/90) |
| `runs` | independent launches; **5 is the minimum that calibrates** |
| `both` | also run `ci` afterwards — same runner, same commit — to see whether its p95 tracks `full`'s |

That last input is how the `ci` profile stops being UNVALIDATED, which is the precondition for it ever being allowed to fail a build.

Records upload as a 90-day artifact so the commit that sets `P95_CEILING` can carry its provenance without retyping numbers. 6-hour budget; same cached-browser setup and step timeouts as `smoke`, for the reason that job's comment already gives.

## Why merging this is the unblock

`workflow_dispatch` only appears in the Actions UI once the workflow is on the **default branch**. Until this merges, the calibration run cannot be started at all — so this PR is the gate on every remaining item: the ceiling, the `ci` profile's validation, and the scenery merge that waits on a trustworthy number.

---
_Generated by [Claude Code](https://claude.ai/code/session_0143N12k61TSn7cN3tHuGE8A)_