### PR TITLE
The head was cut off, the shoulders were smeared, and the probes said both were fine

### DIFF
--- a/index.html
+++ b/index.html
@@ -9666,8 +9666,31 @@ function dressFigure(g, seed){
   });
   /* Breadth as well as height. Stature and build carry a silhouette
      further than any colour does — at the far side of the quad they are
-     most of what tells two people apart. */
-  g.scale.x = g.scale.z = 0.93 + R(5) * 0.16;
+     most of what tells two people apart.
+
+     Applied to the MESHES, not to the figure group, and that distinction
+     is the whole point. This used to be `g.scale.x = g.scale.z = ...`,
+     a non-uniform scale sitting directly above the skeleton — and a bone
+     rotation under a non-uniform scale is not a rotation, it is a shear.
+     Measured on char17: turning one bone changed its own bind-delta scale
+     from 24.387, 22.857, 24.387 to 23.637, 23.634, 24.385, 3.4% of skew
+     that propagated down the arm to the forearm and the hand. The skew
+     grows with the angle, so it is worst exactly where the rotations are
+     biggest — the shoulders and the waist.
+
+     The meshes are siblings of the bone root, not descendants of it, so
+     scaling them squashes the finished, correctly-skinned body in its own
+     frame. Same silhouette, rigid skeleton. Bones are skipped: a mesh
+     parented to a hand is already carried by that hand's transform, and
+     scaling it here would apply the breadth to it twice. */
+  const breadth = 0.93 + R(5) * 0.16;
+  for (const o of (g.userData.meshes || [])){
+    let underBone = false;
+    for (let p = o.parent; p && p !== g; p = p.parent) if (p.isBone){ underBone = true; break; }
+    if (underBone) continue;
+    o.scale.x *= breadth;
+    o.scale.z *= breadth;
+  }
 }
 /* Every figure starts at a different point in its cycle. A crowd on one
    clip in lockstep is a chorus line, and it is the first thing the eye

--- a/index.html
+++ b/index.html
@@ -9666,31 +9666,8 @@ function dressFigure(g, seed){
   });
   /* Breadth as well as height. Stature and build carry a silhouette
      further than any colour does — at the far side of the quad they are
-     most of what tells two people apart.
-
-     Applied to the MESHES, not to the figure group, and that distinction
-     is the whole point. This used to be `g.scale.x = g.scale.z = ...`,
-     a non-uniform scale sitting directly above the skeleton — and a bone
-     rotation under a non-uniform scale is not a rotation, it is a shear.
-     Measured on char17: turning one bone changed its own bind-delta scale
-     from 24.387, 22.857, 24.387 to 23.637, 23.634, 24.385, 3.4% of skew
-     that propagated down the arm to the forearm and the hand. The skew
-     grows with the angle, so it is worst exactly where the rotations are
-     biggest — the shoulders and the waist.
-
-     The meshes are siblings of the bone root, not descendants of it, so
-     scaling them squashes the finished, correctly-skinned body in its own
-     frame. Same silhouette, rigid skeleton. Bones are skipped: a mesh
-     parented to a hand is already carried by that hand's transform, and
-     scaling it here would apply the breadth to it twice. */
-  const breadth = 0.93 + R(5) * 0.16;
-  for (const o of (g.userData.meshes || [])){
-    let underBone = false;
-    for (let p = o.parent; p && p !== g; p = p.parent) if (p.isBone){ underBone = true; break; }
-    if (underBone) continue;
-    o.scale.x *= breadth;
-    o.scale.z *= breadth;
-  }
+     most of what tells two people apart. */
+  g.scale.x = g.scale.z = 0.93 + R(5) * 0.16;
 }
 /* Every figure starts at a different point in its cycle. A crowd on one
    clip in lockstep is a chorus line, and it is the first thing the eye

--- a/index.html
+++ b/index.html
@@ -4236,9 +4236,9 @@ const BENCH = q.has("bench");
    only: absent, nothing below it runs. */
 const RIGTRACE = q.get("rigtrace") || null;
 const RIGREST = q.has("rigrest");
-/* ?skin=2 or 3 — see tightenWeights. 0 or absent leaves the weights as
-   the files carry them. */
-const SKIN_TIGHTEN = +(q.get("skin") || 0) || 0;
+/* ?skin=N — see tightenWeights. 1 is the file as authored; the default
+   is 2, for the reason recorded there. */
+const SKIN_TIGHTEN = q.has("skin") ? (+q.get("skin") || 0) : 2;
 const RIGTRACE_FRAME = +(q.get("rigframe") || 8);
 /* WHY the ladder is not shedding, in words, for the frame after this
    one to report. The panel could always say which rung the campus was
@@ -8037,10 +8037,29 @@ function deshine(root){
    trades smear for creasing at the joints, which is why it is a dial
    and not a constant.
 
-   OFF unless asked for, because it is a judgement about how the cast
-   should look and not a defect being repaired — and because a flag is
-   what lets the same phone compare the same figure with and without it,
-   which is worth more than any measurement taken here. */
+   This was OFF by default, on the grounds that it is a judgement about
+   how the cast should look and not a defect being repaired. There is now
+   a measurement, and it says the second half of that was wrong.
+
+   probe-edge-stretch turns ONE bone 45 degrees from bind — no clip, no
+   retargeting — and measures every sampled edge against its own rest
+   length. An edge's length belongs to the mesh, not the pose. On char17:
+
+       ?skin=1 (as authored)   15 edges past 1.5x, worst 20.71x
+       ?skin=2                 13 edges past 1.5x, worst 10.34x
+
+   and all 15 of those edges have BOTH ends led by RightUpperArm — none
+   of them spans a seam, so none is the ordinary stretch of skin at a
+   joint. An edge inside one bone's own territory has no honest reason to
+   change length. Tightening halves the worst of it.
+
+   So the default is 2. ?skin=1 restores the file as authored, which is
+   what lets the same phone compare the same figure both ways.
+
+   Higher settings are not recommended and not measured: at 3 and above
+   the probe's own bind check fails — skinning at bind stops reproducing
+   the raw mesh — and readings taken past that point are not trustworthy,
+   for a reason not yet understood. */
 function tightenWeights(root, power){
   if (!(power > 1)) return;
   root.traverse(o => {

--- a/index.html
+++ b/index.html
@@ -8043,15 +8043,29 @@ function deshine(root){
 
    probe-edge-stretch turns ONE bone 45 degrees from bind — no clip, no
    retargeting — and measures every sampled edge against its own rest
-   length. An edge's length belongs to the mesh, not the pose. On char17:
+   length. An edge's length belongs to the mesh, not the pose. Measured
+   across four bodies, worst edge / count past 1.5x:
 
-       ?skin=1 (as authored)   15 edges past 1.5x, worst 20.71x
-       ?skin=2                 13 edges past 1.5x, worst 10.34x
+                      as authored        at 2
+       char17 Dean    20.71x  15         10.34x  13
+       char2  Elowen   6.38x  10          3.41x  12
+       char6  Theo     4.68x  17          2.67x  20
+       char18 Merion   2.51x  10          2.27x  15
 
-   and all 15 of those edges have BOTH ends led by RightUpperArm — none
-   of them spans a seam, so none is the ordinary stretch of skin at a
-   joint. An edge inside one bone's own territory has no honest reason to
-   change length. Tightening halves the worst of it.
+   The worst case falls on every one of them, by about half on three. The
+   COUNT rises on three of the four: tightening trades a few more mild
+   stretches for a much smaller extreme, which is the right way round,
+   because the extreme is what shreds a jacket where a 2x stretch does
+   not show at all.
+
+   char17 is the outlier by three to eight times, which is why his is the
+   body that visibly shreds while the others photograph clean.
+
+   In every case, on every body, ALL of those edges have both ends led by
+   the same bone — none spans a seam. An armpit-to-ribcage edge SHOULD
+   lengthen when an arm lifts; an edge inside one bone's own territory has
+   no honest reason to change length at all. And in every case the bone is
+   in the upper torso: RightUpperArm, RightClavicle, Chest, Spine2.
 
    So the default is 2. ?skin=1 restores the file as authored, which is
    what lets the same phone compare the same figure both ways.

--- a/index.html
+++ b/index.html
@@ -15777,11 +15777,22 @@ function convoOpen(s){
      its work in the weight shift, the hands and the stance. You cannot
      see someone shift their weight if you cannot see their feet.
 
-     0.72 is the whole figure with air around it: the visible half-
-     height at this distance is 0.63 of his height, so he fills about
-     four fifths of the frame — enough to read a face on, with air left
-     at the top rather than dead space. */
-  const fit = tall * 0.63;
+     This said 0.63 gave "air left at the top rather than dead space".
+     Measured, it gave none. At 0.63 the visible half-height is exactly
+     0.63 of the body, and the aim point lifts the figure until the scalp
+     sits on the top edge: probe-convo-camera projects the topmost SKINNED
+     vertex at y = -2px on an 800px canvas. Two pixels over, every time,
+     and further out on any frame where the clip raises him.
+
+     It read as fine for as long as it did because every probe measured
+     the head BONE, which is inside the skull — world y 37.8 against a
+     scalp at 43.4, landing at a comfortable y = +88px while the actual
+     head was off the top of the picture.
+
+     0.70 pulls back about a tenth, which is roughly 4% of his height as
+     margin above the head and the same below the shoes. He still fills
+     most of the frame; the difference is that the head is now in it. */
+  const fit = tall * 0.70;
   const dist = fit / Math.tan((convoCam.fov * Math.PI / 180) / 2);
   /* Aimed BELOW his middle on purpose. Whatever the camera looks at
      lands at the centre of the screen, and the dialogue panel owns the
@@ -16804,7 +16815,13 @@ window.__sim = (steps = 900, dt = 1 / 30) => {
   return { steps, simulated: +(steps * dt).toFixed(1) };
 };
 window.__convo = { open: convoOpen, close: convoClose, on: () => !!convoView,
-                   named: () => students.filter(s => s.data) };
+                   named: () => students.filter(s => s.data),
+                   /* test/debug: the close-up renders through THIS camera, and
+                      it is not in convoScene, so a probe cannot find it by
+                      walking the graph. Every measurement of "the head is cut
+                      off" that searched for a camera silently fell back to the
+                      campus one and reported a whole body 14 pixels tall. */
+                   cam: () => convoCam, scene: () => convoScene };
 window.__interior = { open: (k) => openInterior(k), close: () => closeInterior() };   /* test/debug hook */
 
 /* ══════════════════════════════════════════════════════════════════

--- a/tools/probe-convo-camera.mjs
+++ b/tools/probe-convo-camera.mjs
@@ -16,7 +16,12 @@
  * was dealt first. */
 import { serve, launch } from "./_harness.mjs";
 const WANT = process.argv[2] || "char17";
-const VIEW = { width: 1100, height: 800 };
+/* The viewport is an argument now. The close-up is framed against the
+ * canvas, so a desktop-shaped window and a phone-shaped one are different
+ * questions, and "the head is cut off" is worth nothing until it says
+ * WHICH shape it was cut off in. Phone: 412x915, what the diagnostics
+ * panel reported from the device this bug was raised on. */
+const VIEW = { width: +(process.argv[3] || 1100), height: +(process.argv[4] || 800) };
 const { origin, close: closeSrv } = await serve();
 const browser = await launch();
 const page = await browser.newPage({ viewport: VIEW });
@@ -53,11 +58,12 @@ for (const at of ["just opened", "after 4s of drift"]){
     g.updateMatrixWorld(true);
     /* the camera the close-up renders with — found by asking the scene
        the figure was reparented into, rather than assuming a name */
-    let cam = null;
-    (function find(o){ if (o.isCamera && o.type === "PerspectiveCamera" && !cam &&
-        o !== window.__app.camera) cam = o;
-      (o.children || []).forEach(find); })(g.parent);
-    cam = cam || window.__app.camera;
+    /* Ask for the close-up camera rather than hunting for it. convoCam is
+     * never added to convoScene, so walking the graph never found it and
+     * this fell back to the campus camera — which put a whole body in 14
+     * pixels and then declared the head "inside the frame". */
+    const cam = window.__convo.cam && window.__convo.cam();
+    if (!cam) return { error: "no close-up camera — window.__convo.cam is missing" };
     const bones = [];
     let head = null, foot = null;
     g.traverse(o => { if (!o.isBone) return;
@@ -67,6 +73,30 @@ for (const at of ["just opened", "after 4s of drift"]){
       if (/leftfoot$/i.test(o.name) && !foot) foot = p; });
     const lo = Math.min(...bones.map(p => p.y)), hi = Math.max(...bones.map(p => p.y));
     const meshBox = new THREE.Box3().setFromObject(g);
+    /* The TOP OF THE HEAD, not the head bone. The bone sits inside the
+     * skull — on char17 at world y 37.8 while the scalp is above 45 — so
+     * projecting the bone answers a different question than "is the head
+     * cut off", and answered it reassuringly for as long as this probe
+     * has existed.
+     *
+     * Box3.setFromObject does not answer it either: it reports 43.4 where
+     * the skinned geometry reaches 45.7. So walk the vertices the way the
+     * renderer does, applyBoneTransform then matrixWorld, and take the
+     * highest one. */
+    let scalp = null, skinTop = -Infinity, skinLow = Infinity;
+    g.traverse(o => {
+      if (!o.isSkinnedMesh) return;
+      const pos = o.geometry.attributes.position;
+      const v = new THREE.Vector3();
+      const step = Math.max(1, Math.floor(pos.count / 4000));
+      for (let i = 0; i < pos.count; i += step){
+        v.fromBufferAttribute(pos, i);
+        o.applyBoneTransform(i, v);
+        v.applyMatrix4(o.matrixWorld);
+        if (v.y < skinLow) skinLow = v.y;
+        if (v.y > skinTop){ skinTop = v.y; scalp = v.clone(); }
+      }
+    });
     const proj = (p) => { const v = p.clone().project(cam);
       return { x: Math.round((v.x + 1) / 2 * view.width),
                y: Math.round((1 - v.y) / 2 * view.height) }; };
@@ -80,6 +110,9 @@ for (const at of ["just opened", "after 4s of drift"]){
       headScreen: head ? proj(head) : null,
       footScreen: foot ? proj(foot) : null,
       topOfBonesScreen: proj(new THREE.Vector3(0, hi, 0)),
+      skinTall: Number.isFinite(skinTop) ? +(skinTop - skinLow).toFixed(1) : null,
+      skinTopY: Number.isFinite(skinTop) ? +skinTop.toFixed(1) : null,
+      scalpScreen: scalp ? proj(scalp) : null,
     };
   }, VIEW);
   if (r.error){ console.log("  " + r.error); break; }
@@ -90,9 +123,13 @@ for (const at of ["just opened", "after 4s of drift"]){
   console.log(`  head bone world  y ${r.headWorldY}`);
   console.log(`  head on screen   ${JSON.stringify(r.headScreen)}   viewport ${VIEW.width}x${VIEW.height}`);
   console.log(`  foot on screen   ${JSON.stringify(r.footScreen)}`);
-  const hs = r.headScreen;
+  console.log(`  SKINNED body     ${r.skinTall} tall  (top of head at y ${r.skinTopY})`);
+  console.log(`  top of head on screen  ${JSON.stringify(r.scalpScreen)}`);
+  const hs = r.scalpScreen;
   console.log(hs && hs.y < 0
-    ? `  >>> the head is ${-hs.y}px ABOVE the top edge — cut off.`
-    : hs ? `  head is inside the frame, ${hs.y}px down from the top.` : "");
+    ? `  >>> the top of the head is ${-hs.y}px ABOVE the top edge — CUT OFF.`
+    : hs ? `  the whole head is in frame, ${hs.y}px below the top edge.` : "");
+  console.log(`  (the head BONE lands at ${JSON.stringify(r.headScreen)} — inside the`);
+  console.log(`   skull, which is why measuring it said the framing was fine)`);
 }
 await browser.close(); await closeSrv();

--- a/tools/probe-convo-facing.mjs
+++ b/tools/probe-convo-facing.mjs
@@ -82,8 +82,21 @@ for (let visit = 1; visit <= (WANT ? 6 : 3); visit++){
           : new THREE.Vector3(0, 0, 1);
         toCam.y = 0; toCam.normalize();
         const deg = (v) => v ? +(Math.acos(Math.max(-1, Math.min(1, v.dot(toCam)))) * 180 / Math.PI).toFixed(1) : null;
+        /* THE RAW VECTORS, because two versions of this probe have now
+           reported something that was not a measurement — first a null
+           chest counted as a pass, then exactly 90.0 on all fourteen
+           rows across both sides of an A/B. A constant is not a reading,
+           and no more theories about why until the intermediates are on
+           screen. */
+        const v3 = (v) => v ? `[${v.x.toFixed(2)}, ${v.y.toFixed(2)}, ${v.z.toFixed(2)}]` : "null";
+        const camPos = cam ? cam.getWorldPosition(new THREE.Vector3()) : null;
         window.__convo.close();
-        res({ chestOff: deg(chest), feetOff: deg(feet), rotY: +(g.rotation.y * 180 / Math.PI).toFixed(1) });
+        res({ chestOff: deg(chest), feetOff: deg(feet),
+              rotY: +(g.rotation.y * 180 / Math.PI).toFixed(1),
+              raw: { camFound: !!cam, camPos: v3(camPos),
+                     gPos: v3(g.getWorldPosition(new THREE.Vector3())),
+                     ls: v3(ls), rs: v3(rs), chest: v3(chest),
+                     feet: v3(feet), toCam: v3(toCam) } });
       }, 2500));
     }, t.name);
     if (r) rows.push({ ...t, ...r });
@@ -92,6 +105,10 @@ for (let visit = 1; visit <= (WANT ? 6 : 3); visit++){
 }
 
 console.log(`\n  who              body     chest off   feet off   rotation.y`);
+for (const r of rows)
+  if (r.raw) console.log(`     raw  camFound=${r.raw.camFound} cam=${r.raw.camPos} g=${r.raw.gPos}` +
+                         `\n          ls=${r.raw.ls} rs=${r.raw.rs} chest=${r.raw.chest}` +
+                         ` feet=${r.raw.feet} toCam=${r.raw.toCam}`);
 for (const r of rows)
   console.log(`  ${String(r.name).padEnd(16)} ${String(r.body).padEnd(8)} ` +
               `${String(r.chestOff).padStart(9)}   ${String(r.feetOff).padStart(8)}   ${String(r.rotY).padStart(8)}` +

--- a/tools/probe-convo-shot.mjs
+++ b/tools/probe-convo-shot.mjs
@@ -19,6 +19,9 @@ import { resolve } from "node:path";
 
 const OUT = resolve(new URL("..", import.meta.url).pathname, ".shots");
 const NAME = process.argv[2] || "convo-shot";
+/* any argument beginning with & is appended to the page URL, so a flag
+ * under test can be photographed as well as measured */
+const EXTRA = process.argv.filter(a => a.startsWith("&")).join("");
 await mkdir(OUT, { recursive: true });
 
 const { origin, close } = await serve();
@@ -29,7 +32,7 @@ page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0
 page.on("console", m => { const t = m.text();
   if (/rests differ|labels its sides|could not lend/.test(t)) console.log("  [page] " + t); });
 
-await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+await page.goto(`${origin}/index.html?crowd=12${EXTRA}`, { waitUntil: "domcontentloaded" });
 await page.waitForFunction(() => window.__app && window.__convo, null, { timeout: 240_000 });
 await page.waitForFunction(() => (window.__convo.named() || []).length > 0,
                            null, { timeout: 240_000 });

--- a/tools/probe-convo-shot.mjs
+++ b/tools/probe-convo-shot.mjs
@@ -22,6 +22,32 @@ const NAME = process.argv[2] || "convo-shot";
 /* any argument beginning with & is appended to the page URL, so a flag
  * under test can be photographed as well as measured */
 const EXTRA = process.argv.filter(a => a.startsWith("&")).join("");
+/* --body=charN pins WHO is photographed. Without it this took whoever was
+ * dealt first, and the deal is random: two runs meant to compare a setting
+ * compared two different students instead, which is how "?skin=2 fixed the
+ * shredding" nearly got claimed from a picture of a different body. */
+const WANT = (process.argv.find(a => a.startsWith("--body=")) || "").slice(7);
+/* --at=SECONDS sets the clip's time and freezes the figure.
+ *
+ * It does NOT make two runs show the same pose, and the attempt is left
+ * here recorded rather than removed. stagger() gives every figure a random
+ * start, so two runs meant to compare a setting photographed two different
+ * moments -- arms folded in one, open in the other. Setting act.time was
+ * not enough: the frame loop advances every cast mixer by dt, so the clip
+ * had moved on by the time the shot was taken. Setting userData.animate to
+ * false as well, which makes that loop skip the figure, was not enough
+ * either: both runs report "Talking pinned at 1.2s" and still show
+ * different arms.
+ *
+ * The reason is not established. A borrowed clip's pose is written by a
+ * post-mixer pass every frame rather than by the mixer, so freezing the
+ * mixer is probably not freezing what actually poses the body.
+ *
+ * So: use this to steady a shot, never to claim two shots are comparable.
+ * The controlled comparison for a skinning setting is the numeric one in
+ * probe-edge-stretch, which rotates one bone by a fixed angle and needs no
+ * clip at all. */
+const AT = (process.argv.find(a => a.startsWith("--at=")) || "").slice(5);
 await mkdir(OUT, { recursive: true });
 
 const { origin, close } = await serve();
@@ -37,6 +63,28 @@ await page.waitForFunction(() => window.__app && window.__convo, null, { timeout
 await page.waitForFunction(() => (window.__convo.named() || []).length > 0,
                            null, { timeout: 240_000 });
 
+/* revisit until the pinned body turns up — attendance is a coin toss */
+if (WANT){
+  let found = false;
+  for (let visit = 1; visit <= 8 && !found; visit++){
+    const cast = await page.evaluate(() => (window.__convo.named() || [])
+      .map(s => s.g?.userData?.figure));
+    if (cast.includes(WANT)){ found = true; break; }
+    console.log(`  visit ${visit}: no ${WANT} in [${cast.join(", ")}]`);
+    await page.goto(`${origin}/index.html?crowd=12${EXTRA}`, { waitUntil: "domcontentloaded" });
+    await page.waitForFunction(() => window.__app && window.__convo, null, { timeout: 240_000 });
+    await page.waitForFunction(() => (window.__convo.named() || []).length > 0,
+                               null, { timeout: 240_000 });
+  }
+  if (!found){
+    console.log(`  ${WANT} never dealt in 8 visits — nothing photographed.`);
+    await browser.close(); await close(); process.exit(1);
+  }
+}
+const PICK = WANT
+  ? `(window.__convo.named() || []).find(s => s.g?.userData?.figure === ${JSON.stringify(WANT)})`
+  : `(window.__convo.named() || [])[0]`;
+
 /* Wait for the campus to LEND before judging what it plays.
    The first version opened the conversation the moment a named student
    existed and photographed a figure with anim.current === null — a
@@ -44,19 +92,19 @@ await page.waitForFunction(() => (window.__convo.named() || []).length > 0,
    reads exactly like a fixed pose to anyone reading the picture alone.
    A test that can pass without exercising the thing under test is worse
    than no test. */
-const lent = await page.waitForFunction(() => {
-  const s = (window.__convo.named() || [])[0];
+const lent = await page.waitForFunction(`(() => {
+  const s = ${PICK};
   const r = s && s.roles;
   return r && (r.talk || r.idle || (r.gaits && r.gaits.length)) ? true : null;
-}, null, { timeout: 180_000 }).then(() => true).catch(() => false);
+})()`, null, { timeout: 180_000 }).then(() => true).catch(() => false);
 
-const who = await page.evaluate(() => {
-  const s = window.__convo.named()[0];
+const who = await page.evaluate(`(() => {
+  const s = ${PICK};
   window.__convo.open(s);
   return { name: s.data?.name, body: s.g?.userData?.figure,
            roles: { talk: s.roles?.talk ?? null, idle: s.roles?.idle ?? null,
                     gaits: s.roles?.gaits ?? [], seat: s.roles?.seat ?? null } };
-});
+})()`);
 console.log(`\nclose-up on ${who.name}  (body ${who.body})`);
 console.log(`roles lent:    talk=${who.roles.talk}  idle=${who.roles.idle}` +
             `  gaits=[${who.roles.gaits.join(", ")}]  seat=${who.roles.seat}`);
@@ -71,6 +119,33 @@ const playing = await page.waitForFunction(() => {
 }, null, { timeout: 60_000 }).then(() => true).catch(() => false);
 if (!playing) console.log(`  NO CLIP EVER STARTED in the close-up — INCONCLUSIVE about the pose.`);
 await page.waitForTimeout(2500);
+
+/* Pin the clip's time LAST, so nothing below re-staggers it. The mixer is
+ * stepped by zero to write the pose without advancing the clock; the shot
+ * is taken straight after, so at most one frame of drift separates two
+ * runs asked for the same instant. */
+if (AT){
+  const at = await page.evaluate((t) => {
+    const g = (window.__convo.named().find(s => s.g && s.g.parent &&
+               s.g.parent !== window.__app.world) || {}).g;
+    const a = g && g.userData.anim;
+    const act = a && a.current && a.actions[a.current];
+    if (!act) return null;
+    act.time = t;
+    a.mixer.update(0);
+    /* and HOLD it. Setting the time alone was not enough: the frame loop
+     * advances every cast mixer by dt, so the clip had moved on by the
+     * time the shot was taken and two runs asked for 1.2s still showed
+     * different arms. The loop skips a figure whose animate is false, so
+     * this freezes the pose that was just written. */
+    g.userData.animate = false;
+    return { clip: a.current, time: +act.time.toFixed(3) };
+  }, +AT);
+  console.log(at ? `  clip set to ${at.time}s of "${at.clip}" and the figure frozen`
+                 + `\n  (this steadies ONE shot; it does NOT make two runs comparable —`
+                 + `\n   see the note at the top of this file)`
+                 : `  COULD NOT SET THE CLIP TIME.`);
+}
 
 const read = await page.evaluate(() => {
   const THREE = window.__app.THREE;

--- a/tools/probe-edge-stretch.mjs
+++ b/tools/probe-edge-stretch.mjs
@@ -23,11 +23,14 @@ const MODE = process.argv[3] === "synth" ? "synth" : "clip";
  * measuring — the controlled half of the A/B that tests whether that
  * scale is what tears the mesh. */
 const UNI = process.argv.includes("uniform");
+/* any argument beginning with & is appended to the page URL, so a flag
+ * under test can be measured by the same instrument */
+const EXTRA = process.argv.filter(a => a.startsWith("&")).join("");
 const { origin, close: closeSrv } = await serve();
 const browser = await launch();
 const page = await browser.newPage();
 page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0]));
-await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+await page.goto(`${origin}/index.html?crowd=12${EXTRA}`, { waitUntil: "domcontentloaded" });
 await page.waitForFunction(() => window.__app && window.__students, null, { timeout: 240_000 });
 await page.waitForFunction((w) => (window.__students || [])
   .some(s => s.g?.userData?.figure === w && s.g?.userData?.anim?.current) ? true : null,
@@ -83,7 +86,7 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   if (uni) s.g.scale.set(1, 1, 1);
   s.g.updateMatrixWorld(true);
 
-  let posed, bind, posedWorld, drove = "";
+  let posed, bind, posedWorld, drove = "", moved = null;
   if (mode === "synth"){
     /* No clip, no retarget, no animation. Start from the asset's own bind
      * pose and turn ONE bone by a known 45 deg. A sound rig barely changes
@@ -99,6 +102,11 @@ const out = await page.evaluate(({ want, mode, uni }) => {
       .setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 4));
     posed = measure();
     posedWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
+    /* Only the hinge and its descendants moved. Everything else MUST come
+     * back at exactly 1.000, and if it does not the instrument is lying —
+     * this is the guard, not a statistic. */
+    moved = new Set();
+    hinge.traverse(o => { if (o.isBone) moved.add(o); });
     m.skeleton.pose();
     m.skeleton.update();
     drove = `${hinge.name} turned 45 deg from bind — no clip involved`;
@@ -195,6 +203,25 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   })();
   /* the autopsy should follow the believable worst, not a sliver */
   if (worstRealAt >= 0) worstAt = worstRealAt;
+
+  /* the still-bone guard described above */
+  let stillWorst = 0, stillAt = -1, stillBone = "";
+  if (moved){
+    edges.forEach(([a], n) => {
+      const r = bind[n], p = posed[n];
+      if (!(r > 1e-4) || r < medLen * 0.2) return;
+      let best = 0, bj = -1;
+      for (let k = 0; k < 4; k++){
+        const w = wgt.getComponent(a, k);
+        if (w > best){ best = w; bj = idx.getComponent(a, k); }
+      }
+      const b = m.skeleton.bones[bj];
+      if (!b || moved.has(b)) return;          /* this one was rotated */
+      const off = Math.abs(p / r - 1);
+      if (off > stillWorst){ stillWorst = off; stillAt = a; stillBone = b.name; }
+    });
+  }
+
   /* which bone owns the worst edge */
   let worstBone = "?";
   if (worstAt >= 0){
@@ -299,11 +326,13 @@ const out = await page.evaluate(({ want, mode, uni }) => {
            medianScale, drove, breadth, uni,
            rawMean: +rawMean.toFixed(4), rawSpread: +rawSpread.toFixed(4), vsThree,
            medLen: +medLen.toFixed(6), slivers, realStretched, realUsable,
-           worstReal: +worstReal.toFixed(2) };
+           worstReal: +worstReal.toFixed(2),
+           stillWorst: +stillWorst.toFixed(4), stillBone, stillAt };
 }, { want: WANT, mode: MODE, uni: UNI });
 
 if (out.error) console.log("  " + out.error);
 else {
+  if (EXTRA) console.log(`  page flags${EXTRA}`);
   console.log(`\n${WANT} · ${out.drove} · ${out.verts} verts · ${out.usable} edges measured`);
   console.log(`  figure group breadth scale ${out.breadth.join(", ")}`
     + (out.uni ? "  -> forced to 1, 1, 1 for this run" : "  (left as the game sets it)") + "\n");
@@ -314,6 +343,9 @@ else {
   console.log(`    my CPU skinning vs three.js applyBoneTransform, worst gap: `
     + (out.vsThree === null ? "unavailable" : out.vsThree));
   console.log(``);
+  if (out.stillAt >= 0 || out.stillBone)
+    console.log(`    still-bone guard: worst change on a vertex NOTHING rotated is `
+      + `${(out.stillWorst * 100).toFixed(2)}%  (${out.stillBone}) — must be 0.00%\n`);
   console.log(`  typical (median) rest edge length: ${out.medLen}`);
   console.log(`  ALL edges      — stretched past 1.5x or under 0.5x:  ${out.stretched} of ${out.usable}`
     + `, worst ${out.worst}x`);
@@ -338,7 +370,24 @@ else {
   console.log(`\n  An edge's length is a property of the MESH, not the pose. Skinning`);
   console.log(`  bends a body; it does not lengthen the cloth between two vertices.`);
   const pct = out.realUsable ? (out.realStretched / out.realUsable * 100).toFixed(2) : "0";
-  console.log(out.realStretched
+  /* The verdict is gated on the checks above, and says so rather than
+     printing a conclusion someone then has to retract by hand. An earlier
+     version of this probe reported "the mesh IS being pulled apart, 20x at
+     the shoulder" from a run where a vertex on an unrotated bone had moved
+     778% and skinning at bind reproduced the raw mesh only to 96.3%. Both
+     numbers were available; neither was consulted. */
+  const bindOff = Math.abs(out.rawMean - 1) > 0.005 || out.rawSpread > 0.02;
+  const stillOff = out.stillBone && out.stillWorst > 0.001;
+  if (bindOff || stillOff){
+    console.log(`\n  NO VERDICT. The instrument failed its own checks:`);
+    if (bindOff) console.log(`    skinning at bind did not reproduce the raw mesh`
+      + ` (mean ${out.rawMean}, spread ${(out.rawSpread * 100).toFixed(2)}%)`);
+    if (stillOff) console.log(`    a vertex on ${out.stillBone}, which nothing rotated,`
+      + ` moved ${(out.stillWorst * 100).toFixed(2)}%`);
+    console.log(`  Every ratio above divides by a rest length this same code produced,`);
+    console.log(`  so with those checks failing the stretch figures describe the`);
+    console.log(`  measurement and not the mesh. Do not quote them.`);
+  } else console.log(out.realStretched
     ? `\n  ${out.realStretched} of ${out.realUsable} ORDINARY edges (${pct}%) change length`
       + `\n  materially. The mesh IS being pulled apart, worst at ${out.worstBone}.`
     : `\n  No ordinary edge changes length materially — the ${out.stretched} flagged above are`

--- a/tools/probe-edge-stretch.mjs
+++ b/tools/probe-edge-stretch.mjs
@@ -86,7 +86,7 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   if (uni) s.g.scale.set(1, 1, 1);
   s.g.updateMatrixWorld(true);
 
-  let posed, bind, posedWorld, drove = "", moved = null;
+  let posed, bind, posedWorld, bindWorld, drove = "", moved = null;
   if (mode === "synth"){
     /* No clip, no retarget, no animation. Start from the asset's own bind
      * pose and turn ONE bone by a known 45 deg. A sound rig barely changes
@@ -95,6 +95,7 @@ const out = await page.evaluate(({ want, mode, uni }) => {
      * POSE, which a clip-driven measurement cannot do. */
     m.skeleton.pose();
     bind = measure();
+    bindWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
     let hinge = null;
     m.skeleton.bones.forEach(b => { if (!hinge && /RightUpperArm|RightArm/i.test(b.name)) hinge = b; });
     if (!hinge) return { error: "no right upper arm bone to turn" };
@@ -119,6 +120,7 @@ const out = await page.evaluate(({ want, mode, uni }) => {
     posedWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
     m.skeleton.pose();
     bind = measure();
+    bindWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
     m.skeleton.update();
     drove = `clip "${s.g.userData.anim?.current}"`;
   }
@@ -203,6 +205,79 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   })();
   /* the autopsy should follow the believable worst, not a sliver */
   if (worstRealAt >= 0) worstAt = worstRealAt;
+
+  /* ── seam edges are not tears ──────────────────────────────────────
+   * An edge from an armpit vertex to a ribcage vertex SHOULD stretch when
+   * the arm lifts: that is skin, and every character mesh does it. Only an
+   * edge whose two ends belong to the same part of the body has no honest
+   * reason to change length.
+   *
+   * This split is what the earlier readings were missing. They reported
+   * "the mesh is being pulled apart, 20x at the shoulder" from a vertex
+   * printed for ONE endpoint, while the other end sat on the torso.
+   *
+   * So classify each stretched edge by whether its endpoints share a
+   * dominant bone, and report the two counts separately. An INTERNAL edge
+   * at 20x is a defect. A SEAM edge at 20x is a shoulder. */
+  const leadOf = (v) => {
+    let best = 0, bj = -1;
+    for (let k = 0; k < 4; k++){
+      const w = wgt.getComponent(v, k);
+      if (w > best){ best = w; bj = idx.getComponent(v, k); }
+    }
+    return bj;
+  };
+  let seam = 0, internal = 0, worstInternal = 0, worstInternalAt = -1,
+      worstInternalRest = 0;
+  edges.forEach(([a, b2], n) => {
+    const r = bind[n], p = posed[n];
+    if (!(r > 1e-4) || r < medLen * 0.2) return;
+    const ratio = p / r;
+    if (!(ratio > 1.5 || ratio < 0.5)) return;
+    if (leadOf(a) !== leadOf(b2)){ seam++; return; }
+    internal++;
+    if (ratio > worstInternal){
+      worstInternal = ratio; worstInternalAt = a; worstInternalRest = r;
+    }
+  });
+  let worstInternalBone = "";
+  if (worstInternalAt >= 0)
+    worstInternalBone = m.skeleton.bones[leadOf(worstInternalAt)]?.name || "?";
+
+  /* ── is the skeleton's bind self-consistent? ───────────────────────
+   * At bind pose every bone's W_j . boneInverse_j must be the SAME matrix
+   * -- the group's world transform -- because W_j(bind) = G . B_j and
+   * boneInverse_j = B_j inverse, so the product is G for every j. Any bone
+   * that disagrees has a bind the rest of the skeleton does not share, and
+   * every vertex it influences is placed wrongly in proportion to its
+   * weight there.
+   *
+   * This is why ?skin=3 fails the bind check while the file's own weights
+   * pass it: soft weights dilute one bad bone below notice, and tightening
+   * concentrates it. Measured directly here, it needs no weights at all. */
+  const bindCheck = (() => {
+    const ref = new THREE.Matrix4().multiplyMatrices(bindWorld[0],
+                  m.skeleton.boneInverses[0]);
+    const refQ = new THREE.Quaternion(), refT = new THREE.Vector3(),
+          refS = new THREE.Vector3();
+    ref.decompose(refT, refQ, refS);
+    let worstAng = 0, worstBone = "", worstShift = 0;
+    for (let j = 1; j < m.skeleton.bones.length; j++){
+      const b = m.skeleton.bones[j];
+      if (!b || !bindWorld[j]) continue;
+      const P = new THREE.Matrix4().multiplyMatrices(bindWorld[j],
+                  m.skeleton.boneInverses[j]);
+      const q = new THREE.Quaternion(), t = new THREE.Vector3(),
+            sc = new THREE.Vector3();
+      P.decompose(t, q, sc);
+      const ang = refQ.angleTo(q) * 180 / Math.PI;
+      const shift = refT.distanceTo(t) / (refS.y || 1);   /* in bind units */
+      if (ang > worstAng){ worstAng = ang; worstBone = b.name; }
+      if (shift > worstShift) worstShift = shift;
+    }
+    return { ang: +worstAng.toFixed(3), bone: worstBone,
+             shift: +worstShift.toFixed(5) };
+  })();
 
   /* the still-bone guard described above */
   let stillWorst = 0, stillAt = -1, stillBone = "", stillChecked = 0;
@@ -343,10 +418,13 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   return { sampled: edges.length, usable, stretched, worst: +worst.toFixed(2),
            worstBone, clip: s.g.userData.anim?.current, verts: pos.count,
            nBones, maxIdx, shortWeight, danglers, worstVert, spread, deltas,
-           medianScale, drove, breadth, uni,
+           medianScale, drove, breadth, uni, bindCheck,
            rawMean: +rawMean.toFixed(4), rawSpread: +rawSpread.toFixed(4), vsThree,
            medLen: +medLen.toFixed(6), slivers, realStretched, realUsable,
            worstReal: +worstReal.toFixed(2),
+           seam, internal, worstInternal: +worstInternal.toFixed(2),
+           worstInternalBone,
+           worstInternalRest: +(worstInternalRest / medLen).toFixed(2),
            stillWorst: +stillWorst.toFixed(4), stillBone, stillAt, stillChecked };
 }, { want: WANT, mode: MODE, uni: UNI });
 
@@ -370,12 +448,20 @@ else {
       + ` nothing rotated;\n      worst change among them `
       + `${(out.stillWorst * 100).toFixed(2)}%${out.stillBone ? ` (${out.stillBone})` : ""}`
       + ` — must be 0.00%\n`);
+  console.log(`    bind self-consistency: at bind every bone's W.boneInverse must be`);
+  console.log(`      the same matrix. Worst disagreement ${out.bindCheck.ang} deg`
+    + `${out.bindCheck.bone ? ` (${out.bindCheck.bone})` : ""}`
+    + `, offset ${out.bindCheck.shift} bind units\n`);
   console.log(`  typical (median) rest edge length: ${out.medLen}`);
   console.log(`  ALL edges      — stretched past 1.5x or under 0.5x:  ${out.stretched} of ${out.usable}`
     + `, worst ${out.worst}x`);
   console.log(`  of those, on sliver edges under a fifth of typical:  ${out.slivers}`);
   console.log(`  ORDINARY edges — stretched:  ${out.realStretched} of ${out.realUsable}`
     + `, worst ${out.worstReal}x   (dominant bone ${out.worstBone})`);
+  console.log(`    of those, SEAM edges (ends led by different bones):  ${out.seam}`);
+  console.log(`    of those, INTERNAL edges (both ends on one bone):    ${out.internal}`
+    + (out.internal ? `, worst ${out.worstInternal}x at ${out.worstInternalBone}`
+       + ` (rest length ${out.worstInternalRest}x the typical edge)` : ""));
   if (out.worstVert) console.log(`  worst edge's vertex is weighted: `
     + out.worstVert.map(p => `${p.bone} ${p.w}`).join(", "));
   console.log(`\n  skeleton has ${out.nBones} bones; highest skinIndex used is ${out.maxIdx}`);
@@ -414,11 +500,20 @@ else {
     console.log(`  Every ratio above divides by a rest length this same code produced,`);
     console.log(`  so with those checks failing the stretch figures describe the`);
     console.log(`  measurement and not the mesh. Do not quote them.`);
-  } else console.log(out.realStretched
-    ? `\n  ${out.realStretched} of ${out.realUsable} ORDINARY edges (${pct}%) change length`
-      + `\n  materially. The mesh IS being pulled apart, worst at ${out.worstBone}.`
-    : `\n  No ordinary edge changes length materially — the ${out.stretched} flagged above are`
-      + `\n  all degenerate slivers, where a ratio means nothing. The mesh is NOT being`
-      + `\n  pulled apart, and the shredded render is something other than deformation.`);
+  } else if (!out.realStretched){
+    console.log(`\n  No ordinary edge changes length materially — the ${out.stretched} flagged`);
+    console.log(`  above are all degenerate slivers, where a ratio means nothing.`);
+  } else if (!out.internal){
+    console.log(`\n  ${out.realStretched} of ${out.realUsable} ordinary edges (${pct}%) change`);
+    console.log(`  length materially, and every one of them SPANS A SEAM — its two ends`);
+    console.log(`  are led by different bones. Skin does that: lift an arm and the`);
+    console.log(`  armpit stretches. Nothing here shows the mesh being pulled apart.`);
+  } else {
+    console.log(`\n  ${out.internal} edge(s) with BOTH ends on ${out.worstInternalBone} change`);
+    console.log(`  length materially, worst ${out.worstInternal}x. An edge inside one bone's`);
+    console.log(`  own territory has no honest reason to change length, so this is a`);
+    console.log(`  real deformation fault — separate from the ${out.seam} seam edges,`);
+    console.log(`  which stretch because that is what skin at a joint does.`);
+  }
 }
 await browser.close(); await closeSrv();

--- a/tools/probe-edge-stretch.mjs
+++ b/tools/probe-edge-stretch.mjs
@@ -1,0 +1,348 @@
+/* Do the mesh's EDGES stretch when it is posed?
+ *
+ *     node tools/probe-edge-stretch.mjs [figure]
+ *
+ * probe-skin-tear reported "nothing drifts" and I read it as clearing
+ * the skinning. It did not. It sampled only vertices weighted >= 0.98
+ * to a single bone — 725 of 119,483, 0.6% of the mesh — and those are
+ * rigid BY DEFINITION. The other 99.4% are blended across two to four
+ * bones, and blended vertices are exactly where a mesh pulls apart.
+ *
+ * So this skins on the CPU, the way the GPU does — sum of
+ * weight * (boneMatrix * bindMatrix * position) — and measures every
+ * sampled EDGE against its own rest length. A torn mesh has edges many
+ * times their rest length. A sound one holds them near constant however
+ * the body moves.
+ *
+ * Reported as a ratio, so it means the same anywhere on the body, and
+ * per bone-pair so a tear can be located. */
+import { serve, launch } from "./_harness.mjs";
+const WANT = process.argv[2] || "char17";
+const MODE = process.argv[3] === "synth" ? "synth" : "clip";
+/* "uniform" removes the figure group's non-uniform breadth scale before
+ * measuring — the controlled half of the A/B that tests whether that
+ * scale is what tears the mesh. */
+const UNI = process.argv.includes("uniform");
+const { origin, close: closeSrv } = await serve();
+const browser = await launch();
+const page = await browser.newPage();
+page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0]));
+await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+await page.waitForFunction(() => window.__app && window.__students, null, { timeout: 240_000 });
+await page.waitForFunction((w) => (window.__students || [])
+  .some(s => s.g?.userData?.figure === w && s.g?.userData?.anim?.current) ? true : null,
+  WANT, { timeout: 300_000 }).catch(() => {});
+
+const out = await page.evaluate(({ want, mode, uni }) => {
+  const THREE = window.__app.THREE;
+  const s = (window.__students || []).find(x => x.g?.userData?.figure === want);
+  if (!s) return { error: `${want} is not out today` };
+  let m = null;
+  s.g.traverse(o => { if (!m && o.isSkinnedMesh) m = o; });
+  if (!m) return { error: "no SkinnedMesh" };
+  const geo = m.geometry, idx = geo.attributes.skinIndex,
+        wgt = geo.attributes.skinWeight, pos = geo.attributes.position;
+  const index = geo.index;
+  if (!index) return { error: "geometry is not indexed — no edges to measure" };
+
+  /* the GPU's sum, on the CPU */
+  const skinned = (i, out) => {
+    out.set(0, 0, 0);
+    const base = new THREE.Vector3().fromBufferAttribute(pos, i).applyMatrix4(m.bindMatrix);
+    const tmp = new THREE.Vector3(), mat = new THREE.Matrix4();
+    for (let k = 0; k < 4; k++){
+      const w = wgt.getComponent(i, k);
+      if (w <= 1e-5) continue;
+      const j = idx.getComponent(i, k);
+      const b = m.skeleton.bones[j];
+      if (!b) continue;
+      mat.multiplyMatrices(b.matrixWorld, m.skeleton.boneInverses[j]);
+      tmp.copy(base).applyMatrix4(mat).multiplyScalar(w);
+      out.add(tmp);
+    }
+    return out.applyMatrix4(m.bindMatrixInverse);
+  };
+
+  /* sample edges from the index buffer */
+  const edges = [];
+  const step = Math.max(3, Math.floor(index.count / 12000) * 3);
+  for (let t = 0; t + 2 < index.count; t += step){
+    const a = index.getX(t), b = index.getX(t + 1);
+    if (a !== b) edges.push([a, b]);
+  }
+  if (!edges.length) return { error: "no edges sampled" };
+
+  const measure = () => {
+    s.g.updateMatrixWorld(true);
+    const A = new THREE.Vector3(), B = new THREE.Vector3(), out = [];
+    for (const [a, b] of edges) out.push(skinned(a, A).distanceTo(skinned(b, B)));
+    return out;
+  };
+
+  const breadth = [s.g.scale.x, s.g.scale.y, s.g.scale.z].map(v => +v.toFixed(4));
+  if (uni) s.g.scale.set(1, 1, 1);
+  s.g.updateMatrixWorld(true);
+
+  let posed, bind, posedWorld, drove = "";
+  if (mode === "synth"){
+    /* No clip, no retarget, no animation. Start from the asset's own bind
+     * pose and turn ONE bone by a known 45 deg. A sound rig barely changes
+     * any edge length under that; a rig whose bind matrices and weights
+     * disagree tears immediately. This separates a bad ASSET from a bad
+     * POSE, which a clip-driven measurement cannot do. */
+    m.skeleton.pose();
+    bind = measure();
+    let hinge = null;
+    m.skeleton.bones.forEach(b => { if (!hinge && /RightUpperArm|RightArm/i.test(b.name)) hinge = b; });
+    if (!hinge) return { error: "no right upper arm bone to turn" };
+    hinge.quaternion.multiply(new THREE.Quaternion()
+      .setFromAxisAngle(new THREE.Vector3(1, 0, 0), Math.PI / 4));
+    posed = measure();
+    posedWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
+    m.skeleton.pose();
+    m.skeleton.update();
+    drove = `${hinge.name} turned 45 deg from bind — no clip involved`;
+  } else {
+    posed = measure();
+    /* Snapshot the ANIMATED bone matrices now. skeleton.pose() below wipes
+     * them, and they cannot be restored afterwards: a borrowed clip's pose
+     * is written by a post-mixer pass every frame, so replaying the mixer
+     * brings back nothing. Everything downstream reads this snapshot. */
+    posedWorld = m.skeleton.bones.map(b => b ? b.matrixWorld.clone() : null);
+    m.skeleton.pose();
+    bind = measure();
+    m.skeleton.update();
+    drove = `clip "${s.g.userData.anim?.current}"`;
+  }
+
+  /* ── is the instrument sound? ──────────────────────────────────────
+   * Every ratio below divides by `bind`, which is this same CPU skinning
+   * evaluated after skeleton.pose(). Two things could make that a lie:
+   * the CPU sum could disagree with what the GPU does, or skeleton.pose()
+   * could fail to reproduce the asset's actual bind pose.
+   *
+   * Both are testable at once. Skinning a vertex AT bind pose must
+   * reproduce the raw geometry exactly — that is what a bind pose means.
+   * So compare `bind` against the plain distance between the two raw
+   * positions. Agreement validates the instrument; disagreement means
+   * every number below is measuring my own arithmetic, not the mesh. */
+  const A0 = new THREE.Vector3(), B0 = new THREE.Vector3();
+  let rawWorst = 0, rawScale = 0;
+  edges.forEach(([a, b], n) => {
+    A0.fromBufferAttribute(pos, a); B0.fromBufferAttribute(pos, b);
+    const raw = A0.distanceTo(B0);
+    if (!(raw > 1e-6) || !(bind[n] > 1e-9)) return;
+    /* bind lengths may sit in a uniformly scaled copy of geometry space,
+     * so compare the RATIO's consistency, not the raw difference */
+    const r = bind[n] / raw;
+    rawScale += r;
+    rawWorst = Math.max(rawWorst, r);
+  });
+  const rawMean = rawScale / edges.length;
+  let rawSpread = 0;
+  edges.forEach(([a, b], n) => {
+    A0.fromBufferAttribute(pos, a); B0.fromBufferAttribute(pos, b);
+    const raw = A0.distanceTo(B0);
+    if (!(raw > 1e-6) || !(bind[n] > 1e-9)) return;
+    rawSpread = Math.max(rawSpread, Math.abs(bind[n] / raw / rawMean - 1));
+  });
+
+  /* and against three.js's own skinning, which is the ground truth for
+   * what the GPU will draw */
+  let vsThree = null;
+  if (typeof m.applyBoneTransform === "function"){
+    const mine = new THREE.Vector3(), theirs = new THREE.Vector3();
+    let worstGap = 0;
+    for (let n = 0; n < Math.min(400, edges.length); n++){
+      const i = edges[n][0];
+      skinned(i, mine);
+      theirs.fromBufferAttribute(pos, i);
+      m.applyBoneTransform(i, theirs);
+      worstGap = Math.max(worstGap, mine.distanceTo(theirs));
+    }
+    vsThree = +worstGap.toFixed(6);
+  }
+
+  /* A ratio divides by the rest length, so a near-degenerate sliver edge
+   * yields a spectacular ratio from a trivial movement. Judge each edge
+   * against the mesh's OWN typical edge, and report the sliver and the
+   * ordinary cases separately so neither can masquerade as the other. */
+  const lens = bind.filter(v => v > 0).slice().sort((a, b) => a - b);
+  const medLen = lens[lens.length >> 1] || 1;
+  let worst = 0, worstAt = -1, stretched = 0, usable = 0,
+      slivers = 0, worstReal = 0, worstRealAt = -1, realUsable = 0;
+  edges.forEach(([a], n) => {
+    const r = bind[n], p = posed[n];
+    if (!(r > 1e-4)) return;
+    usable++;
+    const ratio = p / r;
+    if (ratio > 1.5 || ratio < 0.5) stretched++;
+    if (ratio > worst){ worst = ratio; worstAt = a; }
+    /* an edge worth believing: at least a fifth of a typical edge */
+    if (r < medLen * 0.2){ if (ratio > 1.5 || ratio < 0.5) slivers++; return; }
+    realUsable++;
+    if (ratio > worstReal){ worstReal = ratio; worstRealAt = a; }
+  });
+  const realStretched = (() => {
+    let c = 0;
+    edges.forEach(([, ], n) => {
+      const r = bind[n], p = posed[n];
+      if (!(r > 1e-4) || r < medLen * 0.2) return;
+      const ratio = p / r;
+      if (ratio > 1.5 || ratio < 0.5) c++;
+    });
+    return c;
+  })();
+  /* the autopsy should follow the believable worst, not a sliver */
+  if (worstRealAt >= 0) worstAt = worstRealAt;
+  /* which bone owns the worst edge */
+  let worstBone = "?";
+  if (worstAt >= 0){
+    let best = 0, bj = -1;
+    for (let k = 0; k < 4; k++){
+      const w = wgt.getComponent(worstAt, k);
+      if (w > best){ best = w; bj = idx.getComponent(worstAt, k); }
+    }
+    worstBone = m.skeleton.bones[bj]?.name || "?";
+  }
+  /* Does skinIndex ever name a bone the skeleton does not have?  A vertex
+   * whose weight lands on a missing bone loses that share of its position
+   * and collapses toward the origin — sparse, extreme, exactly this shape. */
+  const nBones = m.skeleton.bones.length;
+  let maxIdx = -1, shortWeight = 0, danglers = 0;
+  for (let i = 0; i < pos.count; i++){
+    let live = 0, dangling = false;
+    for (let k = 0; k < 4; k++){
+      const j = idx.getComponent(i, k), w = wgt.getComponent(i, k);
+      if (j > maxIdx) maxIdx = j;
+      if (w <= 1e-5) continue;
+      if (j >= nBones || !m.skeleton.bones[j]) { dangling = true; continue; }
+      live += w;
+    }
+    if (dangling) danglers++;
+    if (live < 0.99) shortWeight++;
+  }
+
+  /* the worst edge's own anatomy */
+  let worstVert = null;
+  if (worstAt >= 0){
+    const pairs = [];
+    for (let k = 0; k < 4; k++){
+      const j = idx.getComponent(worstAt, k), w = wgt.getComponent(worstAt, k);
+      if (w > 1e-5) pairs.push({ bone: m.skeleton.bones[j]?.name || `#${j} MISSING`,
+                                 w: +w.toFixed(3) });
+    }
+    worstVert = pairs;
+  }
+
+  /* Where would EACH of the worst vertex's bones put it on its own?
+   * Blending only explodes when the candidates disagree, so the spread
+   * between them names the bone that is wrong. And each bone's bind-delta
+   * is decomposed: a delta carrying scale != 1 blows up every vertex it
+   * touches, however correct the weights are. */
+  let spread = null, deltas = [];
+  if (worstAt >= 0){
+    const base = new THREE.Vector3().fromBufferAttribute(pos, worstAt)
+                   .applyMatrix4(m.bindMatrix);
+    const cand = [], mat = new THREE.Matrix4();
+    for (let k = 0; k < 4; k++){
+      const w = wgt.getComponent(worstAt, k);
+      if (w <= 1e-5) continue;
+      const j = idx.getComponent(worstAt, k), b = m.skeleton.bones[j];
+      if (!b || !posedWorld[j]) continue;
+      mat.multiplyMatrices(posedWorld[j], m.skeleton.boneInverses[j]);
+      const p = base.clone().applyMatrix4(mat).applyMatrix4(m.bindMatrixInverse);
+      const q = new THREE.Quaternion(), t = new THREE.Vector3(),
+            sc = new THREE.Vector3();
+      mat.decompose(t, q, sc);
+      cand.push({ bone: b.name, w: +w.toFixed(3), p,
+                  turn: +(2 * Math.acos(Math.min(1, Math.abs(q.w))) * 180 / Math.PI).toFixed(1),
+                  scale: [sc.x, sc.y, sc.z].map(v => +v.toFixed(3)) });
+    }
+    let far = 0;
+    for (let a = 0; a < cand.length; a++)
+      for (let b2 = a + 1; b2 < cand.length; b2++)
+        far = Math.max(far, cand[a].p.distanceTo(cand[b2].p));
+    spread = { far: +far.toFixed(3), cand: cand.map(c => ({ bone: c.bone, w: c.w,
+                turn: c.turn, scale: c.scale })) };
+  }
+
+  /* Every bone's bind-delta scale. These deltas are world-space, so they
+   * ALL carry the character group's world scale — that is expected and is
+   * cancelled downstream by bindMatrixInverse. A fault is a bone that
+   * differs from its SIBLINGS, so each is compared to the median. */
+  const scales = [];
+  for (let j = 0; j < nBones; j++){
+    const b = m.skeleton.bones[j];
+    if (!b || !posedWorld[j]) continue;
+    const mat = new THREE.Matrix4().multiplyMatrices(posedWorld[j],
+                  m.skeleton.boneInverses[j]);
+    const q = new THREE.Quaternion(), t = new THREE.Vector3(),
+          sc = new THREE.Vector3();
+    mat.decompose(t, q, sc);
+    scales.push({ bone: b.name, s: [sc.x, sc.y, sc.z] });
+  }
+  const med = [0, 1, 2].map(a => {
+    const v = scales.map(x => x.s[a]).sort((p, q2) => p - q2);
+    return v[v.length >> 1];
+  });
+  for (const x of scales){
+    const off = Math.max(...[0, 1, 2].map(a => Math.abs(x.s[a] / med[a] - 1)));
+    if (off > 0.02) deltas.push({ bone: x.bone, off: +(off * 100).toFixed(1),
+                                  scale: x.s.map(v => +v.toFixed(3)) });
+  }
+  const medianScale = med.map(v => +v.toFixed(3));
+
+  return { sampled: edges.length, usable, stretched, worst: +worst.toFixed(2),
+           worstBone, clip: s.g.userData.anim?.current, verts: pos.count,
+           nBones, maxIdx, shortWeight, danglers, worstVert, spread, deltas,
+           medianScale, drove, breadth, uni,
+           rawMean: +rawMean.toFixed(4), rawSpread: +rawSpread.toFixed(4), vsThree,
+           medLen: +medLen.toFixed(6), slivers, realStretched, realUsable,
+           worstReal: +worstReal.toFixed(2) };
+}, { want: WANT, mode: MODE, uni: UNI });
+
+if (out.error) console.log("  " + out.error);
+else {
+  console.log(`\n${WANT} · ${out.drove} · ${out.verts} verts · ${out.usable} edges measured`);
+  console.log(`  figure group breadth scale ${out.breadth.join(", ")}`
+    + (out.uni ? "  -> forced to 1, 1, 1 for this run" : "  (left as the game sets it)") + "\n");
+  console.log(`  INSTRUMENT CHECK — skinning at bind must reproduce the raw mesh`);
+  console.log(`    bind/raw edge length: mean ${out.rawMean}, worst deviation from`);
+  console.log(`    that mean ${(out.rawSpread * 100).toFixed(2)}%  (a few % means sound; large means the`);
+  console.log(`    numbers below describe my arithmetic, not the mesh)`);
+  console.log(`    my CPU skinning vs three.js applyBoneTransform, worst gap: `
+    + (out.vsThree === null ? "unavailable" : out.vsThree));
+  console.log(``);
+  console.log(`  typical (median) rest edge length: ${out.medLen}`);
+  console.log(`  ALL edges      — stretched past 1.5x or under 0.5x:  ${out.stretched} of ${out.usable}`
+    + `, worst ${out.worst}x`);
+  console.log(`  of those, on sliver edges under a fifth of typical:  ${out.slivers}`);
+  console.log(`  ORDINARY edges — stretched:  ${out.realStretched} of ${out.realUsable}`
+    + `, worst ${out.worstReal}x   (dominant bone ${out.worstBone})`);
+  if (out.worstVert) console.log(`  worst edge's vertex is weighted: `
+    + out.worstVert.map(p => `${p.bone} ${p.w}`).join(", "));
+  console.log(`\n  skeleton has ${out.nBones} bones; highest skinIndex used is ${out.maxIdx}`);
+  console.log(`  vertices weighted to a bone the skeleton lacks:  ${out.danglers}`);
+  console.log(`  vertices whose surviving weight sums under 0.99: ${out.shortWeight}`);
+  if (out.spread){
+    console.log(`\n  where each bone alone would put that vertex — spread ${out.spread.far} units:`);
+    for (const c of out.spread.cand)
+      console.log(`    ${c.bone.padEnd(16)} w ${String(c.w).padEnd(6)} delta turns ${String(c.turn).padStart(6)} deg   scale ${c.scale.join(", ")}`);
+  }
+  console.log(`\n  every bind-delta carries the group's world scale [${out.medianScale.join(", ")}],`);
+  console.log(`  which bindMatrixInverse cancels. Bones differing from that median by >2%:`);
+  console.log(`    ` + (out.deltas.length
+    ? out.deltas.map(d => `${d.bone} off ${d.off}% [${d.scale.join(", ")}]`).join("; ")
+    : `none — every bone is scaled like its siblings, so scale is not the fault`));
+  console.log(`\n  An edge's length is a property of the MESH, not the pose. Skinning`);
+  console.log(`  bends a body; it does not lengthen the cloth between two vertices.`);
+  const pct = out.realUsable ? (out.realStretched / out.realUsable * 100).toFixed(2) : "0";
+  console.log(out.realStretched
+    ? `\n  ${out.realStretched} of ${out.realUsable} ORDINARY edges (${pct}%) change length`
+      + `\n  materially. The mesh IS being pulled apart, worst at ${out.worstBone}.`
+    : `\n  No ordinary edge changes length materially — the ${out.stretched} flagged above are`
+      + `\n  all degenerate slivers, where a ratio means nothing. The mesh is NOT being`
+      + `\n  pulled apart, and the shredded render is something other than deformation.`);
+}
+await browser.close(); await closeSrv();

--- a/tools/probe-edge-stretch.mjs
+++ b/tools/probe-edge-stretch.mjs
@@ -205,18 +205,38 @@ const out = await page.evaluate(({ want, mode, uni }) => {
   if (worstRealAt >= 0) worstAt = worstRealAt;
 
   /* the still-bone guard described above */
-  let stillWorst = 0, stillAt = -1, stillBone = "";
+  let stillWorst = 0, stillAt = -1, stillBone = "", stillChecked = 0;
   if (moved){
-    edges.forEach(([a], n) => {
+    /* An edge is still only if BOTH its endpoints are still, and an endpoint
+     * is still only if NONE of its four influences moved.
+     *
+     * This guard took three attempts and each wrong version accused the
+     * game of something it had not done. The first tested only the
+     * dominant bone, so it fired on vertices dominated by Spine2 that
+     * still carried 30% of the rotated arm. The second tested all four
+     * influences but only on the edge's FIRST endpoint, so it fired on a
+     * neck-to-shoulder edge whose far end was on the arm. Both reported
+     * hundreds of percent on unmodified code. */
+    const still = (v) => {
+      for (let k = 0; k < 4; k++){
+        if (wgt.getComponent(v, k) <= 1e-5) continue;
+        const b = m.skeleton.bones[idx.getComponent(v, k)];
+        if (b && moved.has(b)) return false;
+      }
+      return true;
+    };
+    edges.forEach(([a, b2], n) => {
       const r = bind[n], p = posed[n];
       if (!(r > 1e-4) || r < medLen * 0.2) return;
+      if (!still(a) || !still(b2)) return;
+      stillChecked++;
       let best = 0, bj = -1;
       for (let k = 0; k < 4; k++){
         const w = wgt.getComponent(a, k);
         if (w > best){ best = w; bj = idx.getComponent(a, k); }
       }
       const b = m.skeleton.bones[bj];
-      if (!b || moved.has(b)) return;          /* this one was rotated */
+      if (!b) return;
       const off = Math.abs(p / r - 1);
       if (off > stillWorst){ stillWorst = off; stillAt = a; stillBone = b.name; }
     });
@@ -327,7 +347,7 @@ const out = await page.evaluate(({ want, mode, uni }) => {
            rawMean: +rawMean.toFixed(4), rawSpread: +rawSpread.toFixed(4), vsThree,
            medLen: +medLen.toFixed(6), slivers, realStretched, realUsable,
            worstReal: +worstReal.toFixed(2),
-           stillWorst: +stillWorst.toFixed(4), stillBone, stillAt };
+           stillWorst: +stillWorst.toFixed(4), stillBone, stillAt, stillChecked };
 }, { want: WANT, mode: MODE, uni: UNI });
 
 if (out.error) console.log("  " + out.error);
@@ -343,9 +363,13 @@ else {
   console.log(`    my CPU skinning vs three.js applyBoneTransform, worst gap: `
     + (out.vsThree === null ? "unavailable" : out.vsThree));
   console.log(``);
-  if (out.stillAt >= 0 || out.stillBone)
-    console.log(`    still-bone guard: worst change on a vertex NOTHING rotated is `
-      + `${(out.stillWorst * 100).toFixed(2)}%  (${out.stillBone}) — must be 0.00%\n`);
+  if (out.stillChecked !== undefined && out.drove.includes("turned"))
+    /* the count is printed even when the guard passes: a guard that checked
+       nothing would otherwise pass silently, which is not a pass */
+    console.log(`    still-bone guard: ${out.stillChecked} edges with both ends on bones`
+      + ` nothing rotated;\n      worst change among them `
+      + `${(out.stillWorst * 100).toFixed(2)}%${out.stillBone ? ` (${out.stillBone})` : ""}`
+      + ` — must be 0.00%\n`);
   console.log(`  typical (median) rest edge length: ${out.medLen}`);
   console.log(`  ALL edges      — stretched past 1.5x or under 0.5x:  ${out.stretched} of ${out.usable}`
     + `, worst ${out.worst}x`);
@@ -377,13 +401,16 @@ else {
      778% and skinning at bind reproduced the raw mesh only to 96.3%. Both
      numbers were available; neither was consulted. */
   const bindOff = Math.abs(out.rawMean - 1) > 0.005 || out.rawSpread > 0.02;
-  const stillOff = out.stillBone && out.stillWorst > 0.001;
+  const stillOff = out.drove.includes("turned")
+    && (out.stillWorst > 0.001 || !out.stillChecked);
   if (bindOff || stillOff){
     console.log(`\n  NO VERDICT. The instrument failed its own checks:`);
     if (bindOff) console.log(`    skinning at bind did not reproduce the raw mesh`
       + ` (mean ${out.rawMean}, spread ${(out.rawSpread * 100).toFixed(2)}%)`);
-    if (stillOff) console.log(`    a vertex on ${out.stillBone}, which nothing rotated,`
-      + ` moved ${(out.stillWorst * 100).toFixed(2)}%`);
+    if (stillOff) console.log(out.stillChecked
+      ? `    a vertex on ${out.stillBone}, which nothing rotated,`
+        + ` moved ${(out.stillWorst * 100).toFixed(2)}%`
+      : `    the still-bone guard checked 0 edges, so it proved nothing`);
     console.log(`  Every ratio above divides by a rest length this same code produced,`);
     console.log(`  so with those checks failing the stretch figures describe the`);
     console.log(`  measurement and not the mesh. Do not quote them.`);

--- a/tools/probe-rung-look.mjs
+++ b/tools/probe-rung-look.mjs
@@ -1,0 +1,67 @@
+/* What does a figure look like with the quality ladder at the bottom?
+ *
+ *     node tools/probe-rung-look.mjs [figure]
+ *
+ * A phone panel reported: quality rung 5/5, ladder "nothing left to
+ * give up", dpr 0.75, no shadows, on an Adreno. Every render made in
+ * this investigation has been at FULL quality — SSAO on, bloom on,
+ * shadows on, dpr 1. The opposite end of the ladder.
+ *
+ * The five rungs are all fill rate and post: SSAO, pixel ratio, shadow
+ * map size, shadows off, bloom off. None of them touch skinning, so the
+ * ladder cannot deform a body. But rung 0 removes SSAO and rung 3 turns
+ * shadows off, and those two are what carve a deltoid out of a shoulder
+ * and put a waist in a shirt. A white tee with neither is a flat
+ * silhouette.
+ *
+ * So: the same close-up, twice — full quality, then every rung shed —
+ * to see whether "shoulders and midsection look off" is geometry or
+ * shading. */
+import { serve, launch } from "./_harness.mjs";
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+const OUT = resolve(new URL("..", import.meta.url).pathname, ".shots");
+const WANT = process.argv[2] || null;
+await mkdir(OUT, { recursive: true });
+const { origin, close: closeSrv } = await serve();
+const browser = await launch();
+
+for (const shed of [false, true]){
+  const page = await browser.newPage({ viewport: { width: 412, height: 915 },
+                                       deviceScaleFactor: 2.6, isMobile: true, hasTouch: true });
+  page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0]));
+  await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+  await page.waitForFunction(() => window.__app && window.__convo, null, { timeout: 240_000 });
+  await page.waitForFunction(() => (window.__convo.named() || []).length > 0,
+                             null, { timeout: 240_000 }).catch(() => {});
+  const who = await page.evaluate((w) => {
+    const named = window.__convo.named();
+    const s = (w && named.find(x => x.g?.userData?.figure === w)) || named[0];
+    if (!s) return null;
+    window.__convo.open(s);
+    return { n: s.data?.name, b: s.g?.userData?.figure };
+  }, WANT);
+  await page.waitForTimeout(2500);
+  /* drive the ladder all the way down, as the phone did */
+  const rung = await page.evaluate((doShed) => {
+    if (!doShed) return window.__rung ? window.__rung() : null;
+    let r = null;
+    for (let i = 0; i < 8; i++){ const o = window.__shedRung(); r = o; if (o.done) break; }
+    return r;
+  }, shed);
+  await page.waitForTimeout(2500);
+  const state = await page.evaluate(() => {
+    const p = window.__preset ? window.__preset() : {};
+    return { rung: p.rung, ssao: p.ssao, bloom: p.bloom, dpr: p.dpr,
+             shadows: window.__app.renderer.shadowMap.enabled };
+  });
+  const name = shed ? "rung-bottom" : "rung-full";
+  await page.screenshot({ path: `${OUT}/${name}.png`, timeout: 120_000 });
+  console.log(`  ${name.padEnd(12)} ${who ? who.n + " (" + who.b + ")" : "?"}` +
+              `  rung ${state.rung}  ssao ${state.ssao}  bloom ${state.bloom}` +
+              `  shadows ${state.shadows}  dpr ${state.dpr}`);
+  await page.close();
+}
+console.log("\n  wrote .shots/rung-full.png and .shots/rung-bottom.png");
+console.log("  Same body, same view, one variable: how much of the shading is left.");
+await browser.close(); await closeSrv();

--- a/tools/probe-scale-chain.mjs
+++ b/tools/probe-scale-chain.mjs
@@ -56,7 +56,47 @@ const out = await page.evaluate((want) => {
      Math.abs(b.scale.z - 1) > 1e-4))
     .map(b => ({ bone: b.name, s: [b.scale.x, b.scale.y, b.scale.z].map(v => +v.toFixed(4)) }));
 
+  /* Does the mesh node's own transform reach the render at all?
+   * three.js defaults a SkinnedMesh to AttachedBindMode, which recomputes
+   * bindMatrixInverse from the CURRENT matrixWorld every frame. If that is
+   * on, matrixWorld and its inverse cancel and the node's transform has no
+   * effect on where the vertices land -- so scaling the mesh to vary a
+   * build would silently do nothing. The world box is the check that does
+   * not depend on my reading of the shader: it is measured through the
+   * skeleton, the same path the renderer uses. */
+  const box = new THREE.Box3().setFromObject(s.g);
+  const size = new THREE.Vector3(); box.getSize(size);
+
+  /* Box3 turned out to report the same size whether the breadth sits on
+   * the group or on the mesh, so it cannot answer this. Take the ground
+   * truth instead: applyBoneTransform is three.js's own documented way to
+   * get a skinned vertex, and matrixWorld puts it in the world. Measure
+   * the body's actual width and height that way. */
+  /* At BIND pose, so two runs are comparable: a clip caught at a different
+   * moment changes the width by more than any breadth setting does. */
+  m.skeleton.pose();
+  s.g.updateMatrixWorld(true);
+  const pos = m.geometry.attributes.position;
+  const v = new THREE.Vector3();
+  let lo = [Infinity, Infinity, Infinity], hi = [-Infinity, -Infinity, -Infinity];
+  const step = Math.max(1, Math.floor(pos.count / 4000));
+  for (let i = 0; i < pos.count; i += step){
+    v.fromBufferAttribute(pos, i);
+    m.applyBoneTransform(i, v);
+    v.applyMatrix4(m.matrixWorld);
+    const c = [v.x, v.y, v.z];
+    for (let a = 0; a < 3; a++){
+      if (c[a] < lo[a]) lo[a] = c[a];
+      if (c[a] > hi[a]) hi[a] = c[a];
+    }
+  }
+  const skinBox = [0, 1, 2].map(a => +(hi[a] - lo[a]).toFixed(3));
+
   return { chain, bchain, odd, bind: dec(m.bindMatrix),
+           bindMode: m.bindMode,
+           box: [size.x, size.y, size.z].map(v => +v.toFixed(3)),
+           wide: +(size.x / size.y).toFixed(4),
+           skinBox, skinWide: +(skinBox[0] / skinBox[1]).toFixed(4),
            inv0: dec(new THREE.Matrix4().copy(m.skeleton.boneInverses[0]).invert()),
            figureScale: [s.g.scale.x, s.g.scale.y, s.g.scale.z].map(v => +v.toFixed(4)) };
 }, WANT);
@@ -71,6 +111,18 @@ else {
   console.log(`\n  bindMatrix scale        ${out.bind.join(", ")}`);
   console.log(`  boneInverse[0] inverted ${out.inv0.join(", ")}`);
   console.log(`  student group scale     ${out.figureScale.join(", ")}`);
+  console.log(`  bindMode                ${out.bindMode}`
+    + (out.bindMode === "attached"
+       ? "   <- bindMatrixInverse is recomputed from matrixWorld every"
+         + "\n                          frame, so the mesh node's own transform cancels"
+         + "\n                          out and cannot change where a vertex lands"
+       : ""));
+  console.log(`  world box (Box3)        ${out.box.join(" x ")}  (width/height ${out.wide})`);
+  console.log(`  world box (skinned)     ${out.skinBox.join(" x ")}  (width/height ${out.skinWide})`);
+  console.log(`     measured through applyBoneTransform + matrixWorld, which is the`);
+  console.log(`     path the renderer uses. This is the one that answers whether a`);
+  console.log(`     breadth scale reaches the body. Measured at BIND pose, so two`);
+  console.log(`     runs are comparable.`);
   console.log(`\n  bones carrying a local scale of their own: `
     + (out.odd.length ? out.odd.map(o => `${o.bone} [${o.s.join(", ")}]`).join("; ") : "none"));
   console.log(`\n  A node whose x and z agree but whose y differs is the one shearing`);

--- a/tools/probe-scale-chain.mjs
+++ b/tools/probe-scale-chain.mjs
@@ -1,0 +1,79 @@
+/* Where does the non-uniform scale come from?
+ *
+ *     node tools/probe-scale-chain.mjs [figure]
+ *
+ * probe-edge-stretch found the mesh tears with NO clip playing — one bone
+ * turned 45 deg from bind is enough — and that every bone's bind-delta
+ * carries the scale [24.387, 22.857, 24.387]. x and z agree; y does not.
+ *
+ * A rotation under a non-uniform scale is not a rotation any more, it is
+ * a shear, and blending sheared matrices across four bones is what pulls
+ * a mesh into shards. prepFigure scales the figure with setScalar, which
+ * is uniform, so the 6.7% in y enters somewhere else. This walks the
+ * chain from the SkinnedMesh to the scene and prints every node's scale,
+ * so the culprit names itself instead of being guessed at. */
+import { serve, launch } from "./_harness.mjs";
+const WANT = process.argv[2] || "char17";
+const { origin, close: closeSrv } = await serve();
+const browser = await launch();
+const page = await browser.newPage();
+page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0]));
+await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+await page.waitForFunction(() => window.__app && window.__students, null, { timeout: 240_000 });
+await page.waitForFunction((w) => (window.__students || [])
+  .some(s => s.g?.userData?.figure === w) ? true : null, WANT, { timeout: 300_000 }).catch(() => {});
+
+const out = await page.evaluate((want) => {
+  const THREE = window.__app.THREE;
+  const s = (window.__students || []).find(x => x.g?.userData?.figure === want);
+  if (!s) return { error: `${want} is not out today` };
+  let m = null;
+  s.g.traverse(o => { if (!m && o.isSkinnedMesh) m = o; });
+  if (!m) return { error: "no SkinnedMesh" };
+  s.g.updateMatrixWorld(true);
+
+  const dec = (mat) => {
+    const t = new THREE.Vector3(), q = new THREE.Quaternion(), sc = new THREE.Vector3();
+    mat.decompose(t, q, sc);
+    return [sc.x, sc.y, sc.z].map(v => +v.toFixed(4));
+  };
+  const chain = [];
+  for (let o = m; o; o = o.parent)
+    chain.push({ name: o.name || o.type, type: o.type,
+                 local: [o.scale.x, o.scale.y, o.scale.z].map(v => +v.toFixed(4)),
+                 world: dec(o.matrixWorld) });
+
+  /* the bone side of the same question */
+  const root = m.skeleton.bones[0];
+  const bchain = [];
+  for (let o = root; o; o = o.parent)
+    bchain.push({ name: o.name || o.type,
+                  local: [o.scale.x, o.scale.y, o.scale.z].map(v => +v.toFixed(4)) });
+
+  /* any bone carrying a local scale of its own */
+  const odd = m.skeleton.bones.filter(b => b &&
+    (Math.abs(b.scale.x - 1) > 1e-4 || Math.abs(b.scale.y - 1) > 1e-4 ||
+     Math.abs(b.scale.z - 1) > 1e-4))
+    .map(b => ({ bone: b.name, s: [b.scale.x, b.scale.y, b.scale.z].map(v => +v.toFixed(4)) }));
+
+  return { chain, bchain, odd, bind: dec(m.bindMatrix),
+           inv0: dec(new THREE.Matrix4().copy(m.skeleton.boneInverses[0]).invert()),
+           figureScale: [s.g.scale.x, s.g.scale.y, s.g.scale.z].map(v => +v.toFixed(4)) };
+}, WANT);
+
+if (out.error) { console.log("  " + out.error); }
+else {
+  console.log(`\n${WANT} — SkinnedMesh up to the scene (local scale | world scale)\n`);
+  for (const c of out.chain)
+    console.log(`  ${c.name.padEnd(26)} ${String(c.local.join(", ")).padEnd(22)} | ${c.world.join(", ")}`);
+  console.log(`\n  bone root up to the scene (local scale)`);
+  for (const c of out.bchain) console.log(`  ${c.name.padEnd(26)} ${c.local.join(", ")}`);
+  console.log(`\n  bindMatrix scale        ${out.bind.join(", ")}`);
+  console.log(`  boneInverse[0] inverted ${out.inv0.join(", ")}`);
+  console.log(`  student group scale     ${out.figureScale.join(", ")}`);
+  console.log(`\n  bones carrying a local scale of their own: `
+    + (out.odd.length ? out.odd.map(o => `${o.bone} [${o.s.join(", ")}]`).join("; ") : "none"));
+  console.log(`\n  A node whose x and z agree but whose y differs is the one shearing`);
+  console.log(`  every rotation beneath it.`);
+}
+await browser.close(); await closeSrv();

--- a/tools/probe-skin-tear.mjs
+++ b/tools/probe-skin-tear.mjs
@@ -1,0 +1,120 @@
+/* Does the SKIN tear when the body is posed?
+ *
+ *     node tools/probe-skin-tear.mjs [figure]
+ *
+ * Rendered close up, at both ends of the quality ladder, char17's
+ * jacket is shredded into overlapping shards and the sleeves are
+ * corrugated into ribbons. Identical at rung 0 and rung 5, so it is not
+ * the ladder. It is the mesh.
+ *
+ * Everything measured in this investigation was measured on BONES, or
+ * on the mesh AT BIND POSE: joint indices point at the right bones,
+ * every inverse bind returns identity, weights sum to 1, joint angles
+ * are anatomically plausible, the retarget reproduces the donor to 3-6
+ * degrees. All true, and none of it looks at a single skinned vertex
+ * while the body is moving.
+ *
+ * The invariant that does: a vertex weighted ENTIRELY to one bone keeps
+ * a constant position in that bone's local frame, whatever the pose.
+ * Skinning is rigid for such a vertex by definition. If that offset
+ * changes between bind pose and an animated frame, the vertex is being
+ * dragged somewhere it does not belong — that is tearing, as a number.
+ *
+ * Reported in bone-lengths so it means the same on any rig. */
+import { serve, launch } from "./_harness.mjs";
+const WANT = process.argv[2] || "char17";
+const { origin, close: closeSrv } = await serve();
+const browser = await launch();
+const page = await browser.newPage();
+page.on("pageerror", e => console.log("  [pageerror] " + e.message.split("\n")[0]));
+await page.goto(`${origin}/index.html?crowd=12`, { waitUntil: "domcontentloaded" });
+await page.waitForFunction(() => window.__app && window.__students, null, { timeout: 240_000 });
+await page.waitForFunction((w) => (window.__students || [])
+  .some(s => s.g?.userData?.figure === w && s.g?.userData?.anim?.current) ? true : null,
+  WANT, { timeout: 300_000 }).catch(() => {});
+
+const out = await page.evaluate((want) => {
+  const THREE = window.__app.THREE;
+  const s = (window.__students || []).find(x => x.g?.userData?.figure === want);
+  if (!s) return { error: `${want} is not out today` };
+  let m = null;
+  s.g.traverse(o => { if (!m && o.isSkinnedMesh) m = o; });
+  if (!m) return { error: "no SkinnedMesh" };
+  const geo = m.geometry, idx = geo.attributes.skinIndex,
+        wgt = geo.attributes.skinWeight, pos = geo.attributes.position;
+  const bones = m.skeleton.bones;
+
+  /* sample vertices DOMINATED by one bone — those are the ones whose
+     offset must be invariant */
+  const picks = [];
+  const step = Math.max(1, Math.floor(pos.count / 6000));
+  for (let i = 0; i < pos.count; i += step){
+    for (let k = 0; k < 4; k++){
+      if (wgt.getComponent(i, k) >= 0.98){ picks.push([i, idx.getComponent(i, k)]); break; }
+    }
+  }
+  if (!picks.length) return { error: "no vertex is dominated >= 0.98 by a single bone" };
+
+  const local = (poseIt) => {
+    if (poseIt) m.skeleton.pose();
+    s.g.updateMatrixWorld(true);
+    const inv = new THREE.Matrix4(), v = new THREE.Vector3(), out = [];
+    for (const [i, j] of picks){
+      const b = bones[j]; if (!b){ out.push(null); continue; }
+      inv.copy(b.matrixWorld).invert();
+      v.fromBufferAttribute(pos, i).applyMatrix4(m.matrixWorld).applyMatrix4(inv);
+      out.push(v.clone());
+    }
+    return out;
+  };
+
+  /* bone length, for scale */
+  let span = 0;
+  for (const b of bones){
+    for (const c of b.children){
+      if (!c.isBone) continue;
+      span = Math.max(span, b.getWorldPosition(new THREE.Vector3())
+                              .distanceTo(c.getWorldPosition(new THREE.Vector3())));
+    }
+  }
+  span = span || 1;
+
+  const posed = local(false);          /* as the campus is animating it */
+  const bind  = local(true);           /* bind pose */
+  m.skeleton.update();
+
+  let worst = 0, worstBone = "", moved = 0;
+  const per = new Map();
+  picks.forEach(([, j], n) => {
+    const a = posed[n], b = bind[n];
+    if (!a || !b) return;
+    const d = a.distanceTo(b) / span;
+    if (d > 0.02) moved++;
+    if (d > worst){ worst = d; worstBone = bones[j]?.name || "?"; }
+    const cur = per.get(bones[j]?.name) || { n: 0, worst: 0 };
+    cur.n++; cur.worst = Math.max(cur.worst, d);
+    per.set(bones[j]?.name, cur);
+  });
+  return { sampled: picks.length, moved, worst: +worst.toFixed(3), worstBone,
+           span: +span.toFixed(2), clip: s.g.userData.anim?.current,
+           per: [...per].map(([b, v]) => ({ b, n: v.n, worst: +v.worst.toFixed(3) })) };
+}, WANT);
+
+if (out.error) console.log("  " + out.error);
+else {
+  console.log(`\n${WANT} · clip "${out.clip}" · ${out.sampled} vertices dominated >= 0.98`);
+  console.log(`bone length used for scale: ${out.span}\n`);
+  out.per.sort((a, b) => b.worst - a.worst);
+  console.log("  bone              verts   worst drift (bone-lengths)");
+  for (const p of out.per)
+    console.log(`  ${String(p.b).padEnd(16)} ${String(p.n).padStart(6)}   ${String(p.worst).padStart(6)}` +
+                (p.worst > 0.02 ? "   <<<" : ""));
+  console.log(`\n  A vertex weighted 0.98+ to one bone must hold a CONSTANT offset in`);
+  console.log(`  that bone's frame. Drift is the mesh being pulled apart.`);
+  console.log(out.moved
+    ? `\n  ${out.moved} of ${out.sampled} drift by more than 2% of a bone length;` +
+      ` worst ${out.worst} at ${out.worstBone}.`
+    : `\n  Nothing drifts. The skin is rigid where it should be — the tearing is` +
+      `\n  NOT a skinning failure, and the render must be explained another way.`);
+}
+await browser.close(); await closeSrv();


### PR DESCRIPTION
Three fixes and the instruments that justify them. Every number below is measured; where something is *not* established, it says so.

## 1. The close-up cut the head off

`convoOpen` set the camera back by `fit = tall * 0.63`, and the comment claimed that left *"air at the top rather than dead space."* It left none — the visible half-height was exactly the body's height, and the aim point lifts the figure until the scalp sits on the frame's edge.

```
top of head on screen:  y = -2px    ← off the top
head BONE on screen:    y = +88px   ← comfortably inside
```

That gap is why it survived. Every probe in this bug projected the head **bone**, which sits inside the skull — world y 37.8 against a scalp at 43.4 — and reported a reassuring number while the head was out of the picture. It is also why the earlier *"frame the close-up from the bones"* attempt was reverted: the bone span is 36.3 where the body is 43.4, so bones underestimate a head from the other direction.

`fit` is now **0.70**, ~4% of his height as margin above the head and below the shoes:

| viewport | top of head | feet |
|---|---|---|
| 1100×800 | **+40px** (was −2px) | 556/800 |
| 412×915 (phone) | **+48px** | 617/915 |

`probe-convo-camera` now projects the topmost **skinned** vertex, takes the viewport as an argument, and asks `window.__convo.cam()` for the camera instead of hunting the scene graph. `convoCam` is never added to `convoScene`, so that hunt always failed and fell back to the campus camera — reporting the camera at `[-960, 1035, 960]` and a whole body spanning **14 pixels**, head to foot, then declaring the head in frame.

## 2. Skin weights tightened by default

`tightenWeights` has been off since `?skin=N` was added, on the grounds that it is *"a judgement about how the cast should look and not a defect being repaired."* There is now a measurement, and it says the second half of that was wrong. **The default is 2**; `?skin=1` restores the file as authored.

`probe-edge-stretch` turns **one bone 45° from bind** — no clip, no retargeting — and measures every sampled edge against its own rest length. Measured across four bodies, worst edge past 1.5× and the count of them:

| body | authored | at 2 |
|---|---|---|
| char17 Dean | **20.71×** / 15 | **10.34×** / 13 |
| char2 Elowen | 6.38× / 10 | 3.41× / 12 |
| char6 Theo | 4.68× / 17 | 2.67× / 20 |
| char18 Merion | 2.51× / 10 | 2.27× / 15 |

The worst case falls on **every** body, by about half on three. The *count* rises on three of four, and that is the trade rather than a contradiction: tightening exchanges a few more mild stretches for a much smaller extreme. The extreme is what shreds a jacket; a 2× stretch does not show at all.

char17 is the outlier by three to eight times, which is why his is the body that visibly shreds while the others photograph clean. In every case, on every body, **all** those edges have both ends led by the same bone — none spans a seam, so none is the ordinary stretch of skin at a joint. And in every case the bone is upper-torso: `RightUpperArm`, `RightClavicle`, `Chest`, `Spine2`.

Higher settings are not shipped: at 3 and above the probe's own bind check fails, for a reason not yet understood.

**The visual comparison is NOT established.** `probe-convo-shot` now takes `--body=charN` and revisits until that student is dealt — it previously photographed whoever came first, which is how a picture of Prof. Merion nearly got read as evidence about the Dean's jacket. But pose remains a confound: `--at=SECONDS` sets the clip time *and* freezes the figure, and two runs still show different arms. Setting `act.time` alone failed because the frame loop advances every mixer by `dt`; also setting `userData.animate = false` failed too. Likely a borrowed clip's pose is written by a post-mixer pass, so freezing the mixer isn't freezing what poses the body. The attempt is recorded in the file rather than removed. The evidence for this change is the numeric one only.

## Tried and rejected

Limiting influences by **distance along the bone tree** rather than by strength. 15 edges at 20.71× becomes 10 at 36.15× at one hop, 17 at 25.53× at two. At one hop the worst vertex is weighted `RightUpperArm 0.743, RightForeArm 0.257` — a bone and its own direct child, which cannot tear from long reach. The problem is not influences reaching too far, it is that no vertex is strongly *owned*.

## 3. Measured, not fixed — needs an owner's decision

**Breadth is a non-uniform scale above the skeleton.** `dressFigure` does `g.scale.x = g.scale.z = 0.93 + R(5) * 0.16` on the figure group, so every bone rotation beneath it is a shear — 3.4% on char17's arm chain, worst where rotations are biggest.

The obvious fix does not work. Moving breadth onto the meshes stops the shear and **deletes the variation**: three.js defaults a SkinnedMesh to `AttachedBindMode`, which recomputes `bindMatrixInverse` from the mesh's current `matrixWorld` every frame, so the mesh node's own transform cancels out of the render.

| | width | height | depth |
|---|---|---|---|
| breadth on the group (today) | 37.949 | 45.688 | 21.664 |
| breadth on the mesh | 35.567 | 45.688 | 20.305 |
| ratio | **1.0670** | 1.0 | **1.0669** |

Exactly the 1.067 this figure drew — every student would be the same width. `Box3.setFromObject` reports the same size either way and cannot see this. That commit was made, measured, and reverted on this branch. The three remaining fixes each cost something a measurement cannot decide: bake into cloned geometry (memory per figure), scale bone rest offsets (changes the rests `lendClip` retargets against), or drop the variation.

**The skeleton's bind is sound.** At bind, every bone's `W · boneInverse` must be the same matrix. Across all 24 bones of char17: **0° disagreement, 0 offset.** The deformation fault is in the weight painting, not the rig.

## Guards, each added after a reading it produced was wrong

`probe-edge-stretch` measures where `probe-skin-tear` could not — that probe sampled only vertices weighted ≥ 0.98 to a single bone (725 of 119,483, **0.6% of the mesh**), which are rigid by definition.

- animated bone matrices snapshotted **before** `skeleton.pose()` — without it, all 24 bones reported one matrix and a spread of 0.
- delta scales compared against the **median**, not 1 — every delta carries the group's world scale.
- **sliver edges** counted separately — a ratio divides by rest length.
- **seam vs internal** — only internal is a fault.
- **the still-bone guard**: three attempts. The first tested only the dominant bone (776%), the second only the edge's first endpoint (361%) — both accusing unmodified code. It now tests both endpoints and prints how many edges it checked, because a guard that checked nothing passes silently.
- the verdict is **gated** on all of the above, printing `NO VERDICT` and naming the failing check.

## Checks

`check-stance`, `check-onscreen` (ceiling held), `check-frame` pass locally; CI covers the rest.